### PR TITLE
Supervision Control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,6 +1147,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1590,8 @@ dependencies = [
  "cidr-utils",
  "clap",
  "regex",
+ "serde",
+ "tinytemplate",
  "tokio",
  "trust-dns-resolver",
  "trust-dns-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ trust-dns-server = { version = "0.20.2", features = ["trust-dns-resolver"] }
 tokio = { version = "1", features = ["full"] }
 zerotier-central-api = { path = "./zerotier-central-api", version = "1.0.0" }
 zerotier-one-api = { path = "./zerotier-one-api", version = "1.0.0" }
+serde = ">= 0"
+tinytemplate = ">= 0"
 
 [package.metadata.deb]
 copyright = "ZeroTier, Inc"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,27 @@ Setting `ZEROTIER_CENTRAL_TOKEN` in the environment is required. You must be abl
 zeronsd start <network id>
 ```
 
+### Running as a service
+
+_This behavior is currently only supported on Linux; we will accept patches for other platforms._
+
+The `zeronsd supervise` and `zeronsd unsupervise` commands can be used to manipulate systemd unit files related to your network. For the `supervise` case, simply pass the arguments you would normally pass to `start` and it will generate a unit from it.
+
+Example:
+
+```bash
+# to enable
+zeronsd supervise -t ~/.token -f /etc/hosts -d mydomain 36579ad8f6a82ad3
+# generates systemd unit file named /lib/systemd/system/zeronsd-36579ad8f6a82ad3.service
+systemctl daemon-reload
+systemctl enable zeronsd-36579ad8f6a82ad3.service && systemctl start zeronsd-36579ad8f6a82ad3.service
+
+# to disable
+systemctl disable zeronsd-36579ad8f6a82ad3.service && systemctl stop zeronsd-36579ad8f6a82ad3.service
+zeronsd unsupervise 36579ad8f6a82ad3
+systemctl daemon-reload
+```
+
 ### Docker
 
 Running in docker is a little more complicated. You must be able to have a network interface you can import (joined a network) and must be able to reach `localhost:9999` on the host. At this time, for brevity's sake we are recommending running with `--net=host` until we have more time to investigate a potentially more secure solution.
@@ -73,7 +94,9 @@ Running in docker is a little more complicated. You must be able to have a netwo
 You also need to mount your `authtoken.secret`, which we use to talk to `zerotier-one`
 
 ```
+
 docker run -v /var/lib/zerotier-one:/var/lib/zerotier-one:ro --net host zerotier/zeronsd start <network id>
+
 ```
 
 ### Other notes
@@ -108,3 +131,7 @@ ZeroNS demands a lot out of the [trust-dns](https://github.com/bluejekyll/trust-
 ## Author
 
 Erik Hollensbe <github@hollensbe.org>
+
+```
+
+```

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -1,0 +1,164 @@
+use std::path::PathBuf;
+
+use anyhow::anyhow;
+use serde::Serialize;
+use tinytemplate::TinyTemplate;
+use trust_dns_resolver::Name;
+
+const SYSTEMD_SYSTEM_DIR: &str = "/lib/systemd/system";
+const SYSTEMD_UNIT: &str = "
+[Unit]
+Description=zeronsd for network {network}
+Wants=zerotier-one.service
+
+[Service]
+Type=simple
+ExecStart={binpath} start -t {token} {{ if authtoken }}-s {authtoken} {{endif}}{{ if hosts_file }}-f {hosts_file} {{ endif }}{{ if domain }}-d {domain} {{ endif }}{network}
+TimeoutStopSec=30
+
+[Install]
+WantedBy=default.target
+";
+
+#[derive(Serialize)]
+pub struct Properties {
+    binpath: String,
+    domain: Option<String>,
+    network: String,
+    hosts_file: Option<String>,
+    authtoken: Option<String>,
+    token: String,
+}
+
+impl<'a> Properties {
+    pub fn new(
+        domain: Option<&'a str>,
+        network: Option<&'a str>,
+        hosts_file: Option<&'a str>,
+        authtoken: Option<&'a str>,
+        token: Option<&'a str>,
+    ) -> Result<Self, anyhow::Error> {
+        Ok(Self {
+            binpath: String::from(std::env::current_exe()?.to_string_lossy()),
+            // make this garbage a macro later
+            domain: match domain {
+                Some(domain) => Some(String::from(domain)),
+                None => None,
+            },
+            network: network.unwrap().into(),
+            hosts_file: match hosts_file {
+                Some(hosts_file) => Some(String::from(hosts_file)),
+                None => None,
+            },
+            authtoken: match authtoken {
+                Some(authtoken) => Some(String::from(authtoken)),
+                None => None,
+            },
+            token: String::from(token.unwrap_or_default()),
+        })
+    }
+
+    fn validate(&mut self) -> Result<(), anyhow::Error> {
+        let tstat = match std::fs::metadata(self.token.clone()) {
+            Ok(ts) => ts,
+            Err(e) => return Err(anyhow!("Could not stat token file {}: {}", self.token, e)),
+        };
+
+        if !tstat.is_file() {
+            return Err(anyhow!("Token file {} is not a file", self.token));
+        }
+
+        self.token = String::from(std::fs::canonicalize(self.token.clone())?.to_string_lossy());
+
+        if self.network.len() != 16 {
+            return Err(anyhow!("Network ID must be 16 characters"));
+        }
+
+        if let Some(hosts_file) = self.hosts_file.clone() {
+            let hstat = match std::fs::metadata(hosts_file.clone()) {
+                Ok(hs) => hs,
+                Err(e) => return Err(anyhow!("Could not stat hosts file {}: {}", hosts_file, e)),
+            };
+
+            if !hstat.is_file() {
+                return Err(anyhow!("Hosts file {} is not a file", hosts_file));
+            }
+
+            self.hosts_file = Some(
+                std::fs::canonicalize(hosts_file)?
+                    .to_string_lossy()
+                    .to_string(),
+            );
+        }
+
+        if let Some(domain) = self.domain.clone() {
+            match Name::parse(domain.as_str(), None) {
+                Ok(_) => {}
+                Err(e) => return Err(anyhow!("Domain name is invalid: {}", e)),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn systemd_template(&self) -> Result<String, anyhow::Error> {
+        let mut t = TinyTemplate::new();
+        t.add_template("systemd", SYSTEMD_UNIT)?;
+        match t.render("systemd", self) {
+            Ok(x) => Ok(x),
+            Err(e) => Err(anyhow!(e)),
+        }
+    }
+
+    fn service_name(&self) -> String {
+        format!("zeronsd-{}.service", self.network)
+    }
+
+    fn service_path(&self) -> PathBuf {
+        PathBuf::from(SYSTEMD_SYSTEM_DIR).join(self.service_name())
+    }
+
+    pub fn install_supervisor(&mut self) -> Result<(), anyhow::Error> {
+        self.validate()?;
+
+        if cfg!(target_os = "linux") {
+            let template = self.systemd_template()?;
+            let service_path = self.service_path();
+
+            match std::fs::write(service_path.clone(), template) {
+                Ok(_) => {}
+                Err(e) => {
+                    return Err(anyhow!(
+                        "Could not write the template {}; are you root? ({})",
+                        service_path.to_str().unwrap(),
+                        e,
+                    ))
+                }
+            };
+
+            println!(
+                "Service definition written to {}.\nDon't forget to `systemctl daemon-reload` and `systemctl enable zeronsd-{}`",
+                service_path.to_str().unwrap(),
+                self.network,
+            );
+        } else {
+            return Err(anyhow!("Your platform is not supported for this command"));
+        }
+        Ok(())
+    }
+
+    pub fn uninstall_supervisor(&self) -> Result<(), anyhow::Error> {
+        if cfg!(target_os = "linux") {
+            match std::fs::remove_file(self.service_path()) {
+                Ok(_) => Ok(()),
+                Err(e) => Err(anyhow!(
+                    "Could not uninstall supervisor unit file ({}): {}",
+                    self.service_path().to_str().unwrap(),
+                    e
+                )),
+            }
+        } else {
+            Err(anyhow!("Your platform is not supported for this command"))
+        }
+    }
+}


### PR DESCRIPTION
This allows the daemon to register itself as a service, which kind of
side-steps a few of our issues with maintaining multiple copies of the
service for multiple networks.

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>