### PR TITLE
Fix a lot of things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
 # this fun little grep just extracts the version information from Cargo.toml.
 CARGO_VERSION=$$(grep version Cargo.toml | head -1 | awk '{ print $$3 }' | sed 's/"//g') .
 
+build: test
+	cargo build
+
+test:
+	cargo test
+
+test-integration: test
+	TOKEN=${TOKEN} NETWORK=${NETWORK} sudo -E bash -c "$$(which cargo) test -- --ignored"
+
 generate: central service
 
 central:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use authority::ZTAuthority;
+use server::Server;
 use std::io::Write;
 use std::str::FromStr;
 use std::time::Duration;
+use tokio::runtime::Runtime;
 use trust_dns_server::client::rr::Name;
 use zerotier_central_api::apis::configuration::Configuration;
 
@@ -13,6 +15,7 @@ use anyhow::anyhow;
 mod authority;
 mod server;
 mod supervise;
+mod tests;
 
 fn write_help(app: clap::App) -> Result<(), anyhow::Error> {
     let stderr = std::io::stderr();
@@ -41,16 +44,34 @@ fn central_token(arg: Option<&str>) -> Option<String> {
     None
 }
 
-fn authtoken_path() -> Option<&'static str> {
-    if cfg!(target_os = "linux") {
-        Some("/var/lib/zerotier-one/authtoken.secret")
-    } else if cfg!(target_os = "windows") {
-        Some("C:/ProgramData/ZeroTier/One/authtoken.secret")
-    } else if cfg!(target_os = "macos") {
-        Some("/Library/Application Support/ZeroTier/One/authtoken.secret")
+fn authtoken_path(arg: Option<&str>) -> String {
+    if let Some(arg) = arg {
+        return String::from(arg);
     } else {
-        None
+        if cfg!(target_os = "linux") {
+            String::from("/var/lib/zerotier-one/authtoken.secret")
+        } else if cfg!(target_os = "windows") {
+            String::from("C:/ProgramData/ZeroTier/One/authtoken.secret")
+        } else if cfg!(target_os = "macos") {
+            String::from("/Library/Application Support/ZeroTier/One/authtoken.secret")
+        } else {
+            panic!(
+                "authtoken.secret not found; please provide the -s option to provide a custom path"
+            )
+        }
     }
+}
+
+fn domain_or_default(tld: Option<&str>) -> Result<Name, anyhow::Error> {
+    if let Some(tld) = tld {
+        if tld.len() > 0 {
+            return Ok(Name::from_str(&format!("{}.", tld))?);
+        } else {
+            return Err(anyhow!("Domain name must not be empty if provided."));
+        }
+    };
+
+    Ok(Name::from_str(crate::authority::DOMAIN_NAME)?)
 }
 
 async fn get_listen_ip(authtoken_path: &str, network_id: &str) -> Result<String, anyhow::Error> {
@@ -88,6 +109,72 @@ fn supervise(
     supervise::Properties::new(domain, network, hosts_file, authtoken, token)?.install_supervisor()
 }
 
+fn central_config(token: String) -> Configuration {
+    let mut config = Configuration::default();
+    config.bearer_access_token = Some(token);
+    return config;
+}
+
+fn init_runtime() -> Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(4)
+        .thread_name("zeronsd")
+        .build()
+        .expect("failed to initialize tokio")
+}
+
+fn parse_ip_from_cidr(ip_with_cidr: String) -> String {
+    ip_with_cidr.splitn(2, "/").next().unwrap().to_string()
+}
+
+fn init_authority(
+    runtime: &mut Runtime,
+    token: String,
+    network: String,
+    domain_name: Name,
+    hosts_file: Option<String>,
+    ip_with_cidr: String,
+    ip: String,
+) -> Result<Server, anyhow::Error> {
+    let config = central_config(token);
+
+    let authority = ZTAuthority::new(
+        domain_name.clone(),
+        network.clone(),
+        config.clone(),
+        hosts_file,
+        ip_with_cidr.clone(),
+    )?;
+
+    let owned = authority.to_owned();
+    runtime.spawn(owned.find_members());
+
+    let mut zt_network = runtime.block_on(
+        zerotier_central_api::apis::network_api::get_network_by_id(&config, &network),
+    )?;
+
+    let mut domain_name = domain_name.clone();
+    domain_name.set_fqdn(false);
+
+    let dns = Some(Box::new(zerotier_central_api::models::NetworkConfigDns {
+        domain: Some(domain_name.to_string()),
+        servers: Some(Vec::from([String::from(ip.clone())])),
+    }));
+
+    if let Some(mut zt_network_config) = zt_network.config.to_owned() {
+        zt_network_config.dns = dns;
+        zt_network.config = Some(zt_network_config);
+        runtime.block_on(zerotier_central_api::apis::network_api::update_network(
+            &config, &network, zt_network,
+        ))?;
+    }
+
+    Ok(crate::server::Server::new(
+        authority.clone().catalog(runtime)?,
+    ))
+}
+
 fn start(
     domain: Option<&str>,
     network: Option<&str>,
@@ -95,77 +182,35 @@ fn start(
     authtoken: Option<&str>,
     token: Option<&str>,
 ) -> Result<(), anyhow::Error> {
-    let domain_name = if let Some(tld) = domain {
-        Name::from_str(&format!("{}.", tld))?
-    } else {
-        Name::from_str(crate::authority::DOMAIN_NAME)?
-    };
-
-    let authtoken = match authtoken {
-        Some(p) => p,
-        None => authtoken_path().expect(
-            "authtoken.secret not found; please provide the -s option to provide a custom path",
-        ),
-    };
-
-    let mut runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .worker_threads(4)
-        .thread_name("zeronsd")
-        .build()
-        .expect("failed to initialize tokio");
+    let domain_name = domain_or_default(domain)?;
+    let authtoken = authtoken_path(authtoken);
+    let runtime = &mut init_runtime();
 
     if let Some(network) = network {
-        let ip_with_cidr = runtime.block_on(get_listen_ip(authtoken, network))?;
-        let ip = ip_with_cidr.splitn(2, "/").next().unwrap();
+        let ip_with_cidr = runtime.block_on(get_listen_ip(&authtoken, network))?;
+        let ip = parse_ip_from_cidr(ip_with_cidr.clone());
 
         println!("Welcome to ZeroNS!");
         println!("Your IP for this network: {}", ip);
 
         if let Some(token) = central_token(token) {
             let network = String::from(network);
-            let mut config = Configuration::default();
-            config.bearer_access_token = Some(token.clone());
-
             let hf = if let Some(hf) = hosts_file {
                 Some(hf.to_string())
             } else {
                 None
             };
 
-            let authority = ZTAuthority::new(
-                domain_name.clone(),
-                1,
-                network.clone(),
-                config.clone(),
+            let server = init_authority(
+                runtime,
+                token,
+                network,
+                domain_name,
                 hf,
-                ip_with_cidr.clone(),
+                ip_with_cidr,
+                ip.clone(),
             )?;
 
-            let owned = authority.to_owned();
-            runtime.spawn(owned.find_members());
-
-            let mut zt_network = runtime.block_on(
-                zerotier_central_api::apis::network_api::get_network_by_id(&config, &network),
-            )?;
-
-            let mut domain_name = domain_name.clone();
-            domain_name.set_fqdn(false);
-
-            let dns = Some(Box::new(zerotier_central_api::models::NetworkConfigDns {
-                domain: Some(domain_name.to_string()),
-                servers: Some(Vec::from([String::from(ip.clone())])),
-            }));
-
-            if let Some(mut zt_network_config) = zt_network.config.to_owned() {
-                zt_network_config.dns = dns;
-                zt_network.config = Some(zt_network_config);
-                runtime.block_on(zerotier_central_api::apis::network_api::update_network(
-                    &config, &network, zt_network,
-                ))?;
-            }
-
-            let server = crate::server::Server::new(authority.clone().catalog(&mut runtime)?);
             runtime.block_on(server.listen(&format!("{}:53", ip.clone()), Duration::new(0, 1000)))
         } else {
             Err(anyhow!("missing zerotier central token: set ZEROTIER_CENTRAL_TOKEN in environment, or pass a file containing it with -t"))
@@ -179,7 +224,7 @@ fn main() -> Result<(), anyhow::Error> {
     let app = clap::clap_app!(zeronsd =>
         (author: "Erik Hollensbe <github@hollensbe.org>")
         (about: "zerotier central nameserver")
-        (version: "0.1.0")
+        (version: env!("CARGO_PKG_VERSION"))
         (@subcommand start =>
             (about: "Start the nameserver")
             (@arg domain: -d --domain +takes_value "TLD to use for hostnames")

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,268 @@
+struct TestParams {
+    central_token: String,
+    network: String,
+}
+
+/// Set TOKEN and NETWORK to activate integration tests, otherwise they will pass silently.
+/// Requires a pre-configured zerotier network.
+/// You must also be root, and the `-- --ignored` flag must be passed to cargo test.
+fn integration_test_params() -> TestParams {
+    if let Ok(central_token) = std::env::var("TOKEN") {
+        if central_token.trim().len() > 0 {
+            if let Ok(network) = std::env::var("NETWORK") {
+                if network.trim().len() > 0 {
+                    eprintln!("Integration tests activated!");
+                    return TestParams {
+                        central_token,
+                        network,
+                    };
+                }
+            }
+        }
+    }
+
+    panic!("Please provide TOKEN and NETWORK to run these tests");
+}
+
+#[test]
+fn test_parse_ip_from_cidr() {
+    use crate::parse_ip_from_cidr;
+
+    let results = vec![
+        ("192.168.12.1/16", "192.168.12.1"),
+        ("10.0.0.0/8", "10.0.0.0"),
+        ("fe80::abcd/128", "fe80::abcd"),
+    ];
+
+    for (cidr, ip) in results {
+        assert_eq!(
+            parse_ip_from_cidr(String::from(cidr)),
+            String::from(ip),
+            "{}",
+            cidr
+        );
+    }
+}
+
+#[test]
+fn test_domain_or_default() {
+    use crate::{authority::DOMAIN_NAME, domain_or_default};
+    use std::str::FromStr;
+    use trust_dns_server::client::rr::Name;
+
+    assert_eq!(
+        domain_or_default(None).unwrap(),
+        Name::from_str(DOMAIN_NAME).unwrap()
+    );
+
+    assert_eq!(
+        domain_or_default(Some("zerotier")).unwrap(),
+        Name::from_str("zerotier").unwrap()
+    );
+
+    assert_eq!(
+        domain_or_default(Some("zerotier.tld")).unwrap(),
+        Name::from_str("zerotier.tld").unwrap()
+    );
+
+    for bad in vec!["bad.", "~", "!", ".", ""] {
+        assert!(domain_or_default(Some(bad)).is_err(), "{}", bad);
+    }
+}
+
+#[test]
+fn test_central_token() {
+    use crate::central_token;
+
+    assert!(central_token(None).is_none());
+    std::env::set_var("ZEROTIER_CENTRAL_TOKEN", "abcdef");
+    assert!(central_token(None).is_some());
+    assert_eq!(central_token(None).unwrap(), "abcdef");
+
+    let hosts = std::fs::read_to_string("/etc/hosts").unwrap();
+    let token = central_token(Some("/etc/hosts"));
+    assert!(token.is_some());
+    assert_eq!(token.unwrap(), hosts.trim());
+}
+
+#[test]
+#[should_panic]
+fn test_central_token_panic() {
+    use crate::central_token;
+    central_token(Some("/nonexistent"));
+}
+
+#[test]
+#[ignore]
+fn test_get_listen_ip() -> Result<(), anyhow::Error> {
+    use crate::{authtoken_path, get_listen_ip, init_runtime};
+
+    let test_params = integration_test_params();
+    let runtime = init_runtime();
+    let authtoken = authtoken_path(None);
+
+    let listen_ip = runtime.block_on(get_listen_ip(&authtoken, &test_params.network))?;
+    assert_ne!(listen_ip, String::from(""));
+
+    Ok(())
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_supervise_systemd_green() {
+    let table = vec![
+        (
+            "basic",
+            crate::supervise::Properties {
+                binpath: String::from("zeronsd"),
+                network: String::from("1234567891011121"),
+                token: String::from("/proc/cpuinfo"),
+                ..Default::default()
+            },
+        ),
+        (
+            "with-filled-in-properties",
+            crate::supervise::Properties {
+                binpath: String::from("zeronsd"),
+                network: String::from("1234567891011121"),
+                token: String::from("/proc/cpuinfo"),
+                domain: Some(String::from("zerotier")),
+                authtoken: Some(String::from("/var/lib/zerotier-one/authtoken.secret")),
+                hosts_file: Some(String::from("/etc/hosts")),
+            },
+        ),
+    ];
+
+    let write = match std::env::var("WRITE_FIXTURES") {
+        Ok(var) => var != "",
+        Err(_) => false,
+    };
+
+    if write {
+        eprintln!("Write mode: not testing, but updating unit files")
+    }
+
+    for (name, mut props) in table {
+        let path = std::path::PathBuf::from(format!("testdata/supervise/systemd/{}.unit", name));
+
+        if !write {
+            let path = path.canonicalize();
+
+            assert!(path.is_ok(), "{}", name);
+            let expected = std::fs::read_to_string(path.unwrap());
+            assert!(expected.is_ok(), "{}", name);
+            let testing = props.systemd_template();
+            assert!(testing.is_ok(), "{}", name);
+
+            assert_eq!(testing.unwrap(), expected.unwrap(), "{}", name);
+        } else {
+            assert!(props.validate().is_ok(), "{}", name);
+
+            let template = props.systemd_template();
+            assert!(template.is_ok(), "{}", name);
+            assert!(
+                std::fs::write(path, props.systemd_template().unwrap()).is_ok(),
+                "{}",
+                name
+            );
+        }
+    }
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_supervise_systemd_red() {
+    let table = vec![
+        (
+            "bad network",
+            crate::supervise::Properties {
+                binpath: String::from("zeronsd"),
+                network: String::from("123456789101112"),
+                token: String::from("/proc/cpuinfo"),
+                ..Default::default()
+            },
+        ),
+        (
+            "bad token (no file)",
+            crate::supervise::Properties {
+                binpath: String::from("zeronsd"),
+                network: String::from("1234567891011121"),
+                token: String::from("~"),
+                ..Default::default()
+            },
+        ),
+        (
+            "bad token (dir)",
+            crate::supervise::Properties {
+                binpath: String::from("zeronsd"),
+                network: String::from("1234567891011121"),
+                token: String::from("."),
+                ..Default::default()
+            },
+        ),
+        (
+            "bad hosts (no file)",
+            crate::supervise::Properties {
+                binpath: String::from("zeronsd"),
+                network: String::from("1234567891011121"),
+                token: String::from("/proc/cpuinfo"),
+                hosts_file: Some(String::from("~")),
+                ..Default::default()
+            },
+        ),
+        (
+            "bad hosts (dir)",
+            crate::supervise::Properties {
+                binpath: String::from("zeronsd"),
+                network: String::from("1234567891011121"),
+                token: String::from("/proc/cpuinfo"),
+                hosts_file: Some(String::from(".")),
+                ..Default::default()
+            },
+        ),
+        (
+            "bad authtoken (no file)",
+            crate::supervise::Properties {
+                binpath: String::from("zeronsd"),
+                network: String::from("1234567891011121"),
+                token: String::from("/proc/cpuinfo"),
+                authtoken: Some(String::from("~")),
+                ..Default::default()
+            },
+        ),
+        (
+            "bad authtoken (dir)",
+            crate::supervise::Properties {
+                binpath: String::from("zeronsd"),
+                network: String::from("1234567891011121"),
+                token: String::from("/proc/cpuinfo"),
+                authtoken: Some(String::from(".")),
+                ..Default::default()
+            },
+        ),
+        (
+            "bad domain (empty string)",
+            crate::supervise::Properties {
+                binpath: String::from("zeronsd"),
+                network: String::from("1234567891011121"),
+                token: String::from("/proc/cpuinfo"),
+                domain: Some(String::from("")),
+                ..Default::default()
+            },
+        ),
+        (
+            "bad domain (invalid)",
+            crate::supervise::Properties {
+                binpath: String::from("zeronsd"),
+                network: String::from("1234567891011121"),
+                token: String::from("/proc/cpuinfo"),
+                domain: Some(String::from("-")),
+                ..Default::default()
+            },
+        ),
+    ];
+
+    for (name, mut props) in table {
+        assert!(props.validate().is_err(), "{}", name);
+    }
+}

--- a/testdata/supervise/systemd/basic.unit
+++ b/testdata/supervise/systemd/basic.unit
@@ -1,0 +1,12 @@
+
+[Unit]
+Description=zeronsd for network 1234567891011121
+Wants=zerotier-one.service
+
+[Service]
+Type=simple
+ExecStart=zeronsd start -t /proc/cpuinfo 1234567891011121
+TimeoutStopSec=30
+
+[Install]
+WantedBy=default.target

--- a/testdata/supervise/systemd/with-filled-in-properties.unit
+++ b/testdata/supervise/systemd/with-filled-in-properties.unit
@@ -1,0 +1,12 @@
+
+[Unit]
+Description=zeronsd for network 1234567891011121
+Wants=zerotier-one.service
+
+[Service]
+Type=simple
+ExecStart=zeronsd start -t /proc/cpuinfo -s /var/lib/zerotier-one/authtoken.secret -f /etc/hosts -d zerotier 1234567891011121
+TimeoutStopSec=30
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
- Right now, the serial is bumped N times for every API call, which is
  really not great when you consider that systemd-networkd and others
  like it are caching name resolvers.
  - This can be elided by checking if a matching record exists in the
    catalog before inserting it.
- Tests were added. Fixtures in some spots were created. Read
  `src/tests.rs` before trying tests.
  - Code was heavily reorganized as a result.

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>