### PR TITLE
Fix member config and get private networks running for test-integration

### DIFF
--- a/src/authority.rs
+++ b/src/authority.rs
@@ -401,7 +401,7 @@ mod tests {
     use trust_dns_resolver::{
         config::{NameServerConfig, ResolverConfig, ResolverOpts},
         proto::rr::RecordType,
-        IntoName, Name, Resolver,
+        IntoName, Resolver,
     };
 
     use crate::{

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -7,7 +7,7 @@ use std::{
 use tokio::runtime::Runtime;
 use zerotier_central_api::{
     apis::configuration::Configuration,
-    models::{Member, Network},
+    models::{Member, MemberConfig, Network},
 };
 
 async fn get_identity(
@@ -105,6 +105,24 @@ impl TestNetwork {
         let mut member = Member::new();
         member.node_id = Some(identity.clone());
         member.network_id = Some(network.clone().id.unwrap());
+        member.config = Some(Box::new(MemberConfig {
+            v_rev: None,
+            v_major: None,
+            v_proto: None,
+            v_minor: None,
+            tags: None,
+            revision: None,
+            no_auto_assign_ips: Some(false),
+            last_authorized_time: None,
+            last_deauthorized_time: None,
+            id: None,
+            creation_time: None,
+            capabilities: None,
+            ip_assignments: None,
+            authorized: Some(true),
+            active_bridge: None,
+            identity: Some(identity.clone()),
+        }));
 
         runtime
             .lock()

--- a/testdata/networks/basic-ipv4.json
+++ b/testdata/networks/basic-ipv4.json
@@ -17,6 +17,7 @@
     },
     "v6AssignMode": {
       "6plane": false
-    }
+    },
+    "private": true
   }
 }


### PR DESCRIPTION
This makes networks private. Important detail!