### PR TITLE
More tests for named hosts & configurable refresh interval

### DIFF
--- a/src/authority.rs
+++ b/src/authority.rs
@@ -4,6 +4,7 @@ use std::{
     net::IpAddr,
     str::FromStr,
     sync::{Arc, RwLock},
+    time::Duration,
 };
 
 use anyhow::anyhow;
@@ -143,6 +144,7 @@ pub struct ZTAuthority {
     network: String,
     config: Configuration,
     hosts: Box<HostsFile>,
+    update_interval: Duration,
 }
 
 impl ZTAuthority {
@@ -152,6 +154,7 @@ impl ZTAuthority {
         config: Configuration,
         hosts_file: Option<String>,
         listen_ip: String,
+        update_interval: Duration,
     ) -> Result<Arc<Self>, anyhow::Error> {
         let ptr_authority = match IpCidr::from_str(listen_ip)? {
             IpCidr::V4(ip) => {
@@ -177,6 +180,7 @@ impl ZTAuthority {
         };
 
         Ok(Arc::new(Self {
+            update_interval,
             domain_name: domain_name.clone(),
             network,
             config,
@@ -216,7 +220,7 @@ impl ZTAuthority {
                 }
             }
 
-            tokio::time::sleep(std::time::Duration::new(30, 0)).await;
+            tokio::time::sleep(self.update_interval).await;
         }
     }
 

--- a/src/authority/tests.rs
+++ b/src/authority/tests.rs
@@ -13,13 +13,14 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     str::FromStr,
     sync::{Arc, Mutex},
+    thread,
     time::Duration,
 };
 
 use tokio::runtime::Runtime;
 
 struct Service {
-    _runtime: Arc<Mutex<Runtime>>, // this exists to save some typing but get the same effect as a static lifetime
+    runtime: Arc<Mutex<Runtime>>,
     tn: Arc<TestNetwork>,
     resolver: Arc<Resolver>,
     pub listen_ip: String,
@@ -27,7 +28,7 @@ struct Service {
 }
 
 impl Service {
-    fn new(hosts: Option<&str>) -> Self {
+    fn new(hosts: Option<&str>, update_interval: Option<Duration>) -> Self {
         let mut runtime = init_runtime();
         let tn = TestNetwork::new("basic-ipv4").unwrap();
 
@@ -51,6 +52,7 @@ impl Service {
             },
             listen_cidr.clone(),
             listen_ip.clone(),
+            update_interval.unwrap_or(Duration::new(30, 0)),
         )
         .unwrap();
 
@@ -72,12 +74,16 @@ impl Service {
             trust_dns_resolver::Resolver::new(resolver_config, ResolverOpts::default()).unwrap();
 
         Self {
-            _runtime: Arc::new(Mutex::new(runtime)),
+            runtime: Arc::new(Mutex::new(runtime)),
             tn: Arc::new(tn),
             listen_ip,
             listen_cidr,
             resolver: Arc::new(resolver),
         }
+    }
+
+    pub fn runtime(&self) -> Arc<Mutex<Runtime>> {
+        self.runtime.clone()
     }
 
     pub fn network(&self) -> Arc<TestNetwork> {
@@ -119,7 +125,7 @@ impl Service {
 #[test]
 #[ignore]
 fn test_battery_single_domain() {
-    let service = Service::new(None);
+    let service = Service::new(None, None);
 
     let record = format!("zt-{}.domain.", service.network().identity.clone());
 
@@ -177,7 +183,7 @@ fn test_battery_single_domain() {
 #[test]
 #[ignore]
 fn test_battery_multi_domain_hosts_file() {
-    let service = Service::new(Some("basic"));
+    let service = Service::new(Some("basic"), None);
 
     let record = format!("zt-{}.domain.", service.network().identity.clone());
 
@@ -200,5 +206,57 @@ fn test_battery_multi_domain_hosts_file() {
         let host = hosts.first().unwrap();
         let ip = service.lookup_a(host.to_string());
         assert!(hosts_map.get(&ip.into()).unwrap().contains(host));
+    }
+}
+
+#[test]
+#[ignore]
+fn test_battery_single_domain_named() {
+    let update_interval = Duration::new(1, 0);
+    let service = Service::new(None, Some(update_interval));
+    let member_record = format!("zt-{}.domain.", service.network().identity.clone());
+
+    let mut member = service
+        .runtime()
+        .lock()
+        .unwrap()
+        .block_on(
+            zerotier_central_api::apis::network_member_api::get_network_member(
+                &service.network().central,
+                &service.network().network.clone().id.unwrap(),
+                &service.network().identity,
+            ),
+        )
+        .unwrap();
+
+    member.name = Some("islay".to_string());
+
+    service
+        .runtime()
+        .lock()
+        .unwrap()
+        .block_on(
+            zerotier_central_api::apis::network_member_api::update_network_member(
+                &service.network().central,
+                &service.network().network.clone().id.unwrap(),
+                &service.network().identity,
+                member,
+            ),
+        )
+        .unwrap();
+
+    thread::sleep(update_interval); // wait for it to update
+
+    let named_record = "islay.domain.".to_string();
+
+    for record in vec![member_record, named_record] {
+        eprintln!("Looking up {}", record);
+
+        for _ in 0..10000 {
+            assert_eq!(
+                service.lookup_a(record.clone()).to_string(),
+                service.listen_ip
+            );
+        }
     }
 }

--- a/src/authority/tests.rs
+++ b/src/authority/tests.rs
@@ -249,7 +249,7 @@ fn test_battery_single_domain_named() {
 
     let named_record = "islay.domain.".to_string();
 
-    for record in vec![member_record, named_record] {
+    for record in vec![member_record, named_record.clone()] {
         eprintln!("Looking up {}", record);
 
         for _ in 0..10000 {
@@ -258,5 +258,19 @@ fn test_battery_single_domain_named() {
                 service.listen_ip
             );
         }
+    }
+
+    let ptr_record = IpAddr::from_str(&service.listen_ip)
+        .unwrap()
+        .into_name()
+        .unwrap();
+
+    eprintln!("Looking up {}", ptr_record);
+
+    for _ in 0..10000 {
+        assert_eq!(
+            service.lookup_ptr(ptr_record.to_string()),
+            named_record.to_string(),
+        );
     }
 }

--- a/src/authority/tests.rs
+++ b/src/authority/tests.rs
@@ -19,7 +19,7 @@ use std::{
 use tokio::runtime::Runtime;
 
 struct Service {
-    _runtime: Arc<Mutex<Runtime>>,
+    _runtime: Arc<Mutex<Runtime>>, // this exists to save some typing but get the same effect as a static lifetime
     tn: Arc<TestNetwork>,
     resolver: Arc<Resolver>,
     pub listen_ip: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,7 @@ fn init_authority(
     hosts_file: Option<String>,
     ip_with_cidr: String,
     ip: String,
+    update_interval: Duration,
 ) -> Result<Server, anyhow::Error> {
     let config = central_config(token);
 
@@ -150,6 +151,7 @@ fn init_authority(
         config.clone(),
         hosts_file,
         ip_with_cidr.clone(),
+        update_interval,
     )?;
 
     let owned = authority.to_owned();
@@ -214,6 +216,7 @@ fn start(
                 hf,
                 ip_with_cidr,
                 ip.clone(),
+                Duration::new(30, 0),
             )?;
 
             runtime.block_on(server.listen(format!("{}:53", ip.clone()), Duration::new(0, 1000)))


### PR DESCRIPTION
Configurable refresh from central. Not sure how best to safely expose this but we'll add it soon to the CLI toolset.