### PR TITLE
Hosts translation

### DIFF
--- a/src/authority.rs
+++ b/src/authority.rs
@@ -1,8 +1,3 @@
-use crate::{
-    hosts::{parse_hosts, HostsFile},
-    utils::parse_member_name,
-};
-
 use std::{
     net::IpAddr,
     str::FromStr,
@@ -24,6 +19,11 @@ use trust_dns_server::{
     store::{forwarder::ForwardConfig, in_memory::InMemoryAuthority},
 };
 use zerotier_central_api::{apis::configuration::Configuration, models::Member};
+
+use crate::{
+    hosts::{parse_hosts, HostsFile},
+    utils::parse_member_name,
+};
 
 type Authority = Box<Arc<RwLock<InMemoryAuthority>>>;
 type PtrAuthority = Option<Authority>;

--- a/src/authority.rs
+++ b/src/authority.rs
@@ -22,7 +22,7 @@ use zerotier_central_api::{apis::configuration::Configuration, models::Member};
 
 use crate::{
     hosts::{parse_hosts, HostsFile},
-    utils::parse_member_name,
+    utils::{parse_member_name, ToHostname},
 };
 
 type Authority = Box<Arc<RwLock<InMemoryAuthority>>>;
@@ -270,15 +270,15 @@ impl ZTAuthority {
 
         for member in members {
             let member_name = format!("zt-{}", member.node_id.unwrap());
-            let fqdn = Name::from_str(&member_name)?.append_name(&self.domain_name.clone());
+            let fqdn = member_name.to_fqdn(self.domain_name.clone())?;
 
             // this is default the zt-<member id> but can switch to a named name if
             // tweaked in central. see below.
             let mut canonical_name = fqdn.clone();
             let mut member_is_named = false;
 
-            if let Some(name) = parse_member_name(member.name.clone()) {
-                canonical_name = name.append_name(&self.domain_name.clone());
+            if let Some(name) = parse_member_name(member.name.clone(), self.domain_name.clone()) {
+                canonical_name = name;
                 member_is_named = true;
             }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,12 +28,21 @@ fn test_parse_member_name() {
             );
         }
 
-        for bad_name in vec![".", "!", "!foo", "arghle."] {
+        for bad_name in vec![".", "!", "arghle."] {
             assert_eq!(
                 parse_member_name(Some(bad_name.to_string()), domain_name.clone()),
                 None,
                 "{}",
                 bad_name,
+            );
+        }
+
+        for (orig, translated) in vec![("Erik's laptop", "eriks-laptop"), ("!foo", "foo")] {
+            assert_eq!(
+                parse_member_name(Some(orig.to_string()), domain_name.clone()),
+                Some(translated.to_fqdn(domain_name.clone()).unwrap()),
+                "{}",
+                orig,
             );
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use trust_dns_resolver::IntoName;
+use crate::utils::{domain_or_default, ToHostname};
 
 pub const HOSTS_DIR: &str = "testdata/hosts-files";
 
@@ -6,24 +6,36 @@ pub const HOSTS_DIR: &str = "testdata/hosts-files";
 fn test_parse_member_name() {
     use crate::utils::parse_member_name;
 
-    assert_eq!(parse_member_name(None), None);
+    let actual_domains: &mut Vec<Option<&str>> =
+        &mut vec!["tld", "domain", "zerotier", "test.subdomain"]
+            .iter()
+            .map(|s| Some(*s))
+            .collect::<Vec<Option<&str>>>();
 
-    for name in vec!["islay", "ALL-CAPS", "Capitalized", "with.dots"] {
-        assert_eq!(
-            parse_member_name(Some(name.to_string())),
-            Some(name.into_name().unwrap()),
-            "{}",
-            name,
-        );
-    }
+    actual_domains.push(None); // make sure the None case also gets checked
 
-    for bad_name in vec![".", "!", "!foo", "arghle."] {
-        assert_eq!(
-            parse_member_name(Some(bad_name.to_string())),
-            None,
-            "{}",
-            bad_name,
-        );
+    for domain in actual_domains {
+        let domain_name = domain_or_default(*domain).unwrap().clone();
+
+        assert_eq!(parse_member_name(None, domain_name.clone()), None);
+
+        for name in vec!["islay", "ALL-CAPS", "Capitalized", "with.dots"] {
+            assert_eq!(
+                parse_member_name(Some(name.to_string()), domain_name.clone()),
+                Some(name.to_fqdn(domain_name.clone()).unwrap()),
+                "{}",
+                name,
+            );
+        }
+
+        for bad_name in vec![".", "!", "!foo", "arghle."] {
+            assert_eq!(
+                parse_member_name(Some(bad_name.to_string()), domain_name.clone()),
+                None,
+                "{}",
+                bad_name,
+            );
+        }
     }
 }
 


### PR DESCRIPTION
This translates `Erik's laptop` to `eriks-laptop` and should make zeronsd much more compatible with networks that have existing names. Compare with Apple's default DNS setup under the "Sharing" tab.