### PR TITLE
src/supervise.rs: Add `After=zerotier-one.service` to systemd unit template

### DIFF
--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -10,6 +10,7 @@ const SYSTEMD_UNIT: &str = "
 [Unit]
 Description=zeronsd for network {network}
 Wants=zerotier-one.service
+After=zerotier-one.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
This was causing some problems for some users. Thanks @devvick for the
report!

closes #64

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>