### PR TITLE
Small search domain and DNS setup fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,9 @@ fn start(
             update_central_dns(
                 runtime,
                 domain_name.clone(),
-                ips.first().unwrap().to_string(),
+                utils::parse_ip_from_cidr(ips.clone().into_iter()
+                    .find(|i| IpNetwork::from_str(i).expect("Could not parse CIDR").is_ipv4())
+                    .expect("Could not find a valid IPv4 network (currently, ipv6 resolvers are unsupported)")),
                 token.clone(),
                 network.clone(),
             )?;


### PR DESCRIPTION
- Prefer IPv4 addresses (for now at least) and do not advertise IPv6 as
  a nameserver to zerotier central
- Fix an issue where the CIDR netmask was not getting stripped when
  setting the search domain

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>