### PR TITLE
Cleanups

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,10 @@ fn start(
 
             return Ok(runtime.block_on(wait()));
         }
+
+        return Err(anyhow!(
+            "No listening IPs for your interface; assign one in ZeroTier Central."
+        ));
     }
 
     return Err(anyhow!("no network ID"));

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,8 @@
 use std::time::Duration;
-use tokio::net::{TcpListener, UdpSocket};
+use tokio::{
+    net::{TcpListener, UdpSocket},
+    time::sleep,
+};
 
 use trust_dns_resolver::proto::error::ProtoError;
 use trust_dns_server::server::ServerFuture;
@@ -30,7 +33,13 @@ impl Server {
 
             match sf.block_until_done().await {
                 Ok(_) => return Ok(()),
-                Err(e) => eprintln!("Error received: {}. Will attempt to restart listener", e),
+                Err(e) => {
+                    eprintln!(
+                        "Error received: {}. Will attempt to restart listener in one second",
+                        e
+                    );
+                    sleep(Duration::new(1, 0)).await;
+                }
             }
         }
     }

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -9,7 +9,7 @@ const SYSTEMD_SYSTEM_DIR: &str = "/lib/systemd/system";
 const SYSTEMD_UNIT: &str = "
 [Unit]
 Description=zeronsd for network {network}
-Wants=zerotier-one.service
+Requires=zerotier-one.service
 After=zerotier-one.service
 
 [Service]


### PR DESCRIPTION
- Restart listener if it crashes
- Use Requires= over Wants= in systemd supervise template
- Display an error message that's a little more targeted when the network has no listening ips 