### PR TITLE
Wildcards

### DIFF
--- a/src/authority.rs
+++ b/src/authority.rs
@@ -276,6 +276,130 @@ pub(crate) async fn init_catalog(zt: TokioZTAuthority) -> Result<Catalog, std::i
     Ok(catalog)
 }
 
+pub(crate) struct ZTRecord {
+    fqdn: Name,
+    canonical_name: Option<Name>,
+    ptr_name: Name,
+    ips: Vec<IpAddr>,
+    wildcard_everything: bool,
+}
+
+impl ZTRecord {
+    pub(crate) fn new(
+        member: &Member,
+        domain_name: Name,
+        wildcard_everything: bool,
+    ) -> Result<Self, anyhow::Error> {
+        let member_name = format!(
+            "zt-{}",
+            member
+                .clone()
+                .node_id
+                .expect("Node ID for member does not exist")
+        );
+
+        let fqdn = member_name.clone().to_fqdn(domain_name.clone())?;
+
+        // this is default the zt-<member id> but can switch to a named name if
+        // tweaked in central. see below.
+        let mut canonical_name = None;
+        let mut ptr_name = fqdn.clone();
+
+        if let Some(name) = parse_member_name(member.name.clone(), domain_name.clone()) {
+            canonical_name = Some(name.clone());
+            ptr_name = name;
+        }
+
+        let ips: Vec<IpAddr> = member
+            .clone()
+            .config
+            .expect("Member config does not exist")
+            .ip_assignments
+            .expect("IP assignments for member do not exist")
+            .into_iter()
+            .map(|s| IpAddr::from_str(&s).expect("Could not parse IP address"))
+            .collect();
+
+        Ok(Self {
+            wildcard_everything,
+            fqdn,
+            canonical_name,
+            ptr_name,
+            ips,
+        })
+    }
+
+    pub(crate) fn insert(&self, records: &mut Vec<Name>) {
+        records.push(self.fqdn.clone());
+
+        for ip in self.ips.clone() {
+            records.push(ip.into_name().expect("Could not coerce IP into name"));
+        }
+
+        if self.canonical_name.is_some() {
+            records.push(self.canonical_name.clone().unwrap());
+            if self.wildcard_everything {
+                records.push(self.get_canonical_wildcard().unwrap())
+            }
+        }
+
+        if self.wildcard_everything {
+            records.push(self.get_wildcard())
+        }
+    }
+
+    pub(crate) fn get_wildcard(&self) -> Name {
+        Name::from_str("*")
+            .unwrap()
+            .append_name(&self.fqdn)
+            .into_wildcard()
+    }
+
+    pub(crate) fn get_canonical_wildcard(&self) -> Option<Name> {
+        if self.canonical_name.is_none() {
+            return None;
+        }
+
+        Some(
+            Name::from_str("*")
+                .unwrap()
+                .append_name(&self.canonical_name.clone().unwrap())
+                .into_wildcard(),
+        )
+    }
+
+    pub(crate) fn insert_member(&self, authority: &ZTAuthority) -> Result<(), anyhow::Error> {
+        authority.match_or_insert(self.fqdn.clone(), self.ips.clone());
+
+        if self.wildcard_everything {
+            authority.match_or_insert(self.get_wildcard(), self.ips.clone());
+        }
+
+        if self.canonical_name.is_some() {
+            authority.match_or_insert(self.canonical_name.clone().unwrap(), self.ips.clone());
+            if self.wildcard_everything {
+                authority.match_or_insert(self.get_canonical_wildcard().unwrap(), self.ips.clone())
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn insert_member_ptr(
+        &self,
+        authority: &PtrAuthority,
+        records: &mut Vec<Name>,
+    ) -> Result<(), anyhow::Error> {
+        if authority.is_some() {
+            for ip in self.ips.clone() {
+                records.push(ip.into_name().expect("Could not coerce IP into name"));
+                configure_ptr(authority.clone().unwrap(), ip, self.ptr_name.clone())?;
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct ZTAuthority {
     ptr_authority: PtrAuthority,
@@ -372,61 +496,11 @@ impl ZTAuthority {
         }
 
         for member in members {
-            let member_name = format!(
-                "zt-{}",
-                member.node_id.expect("Node ID for member does not exist")
-            );
-            let fqdn = member_name.to_fqdn(self.domain_name.clone())?;
-
-            // this is default the zt-<member id> but can switch to a named name if
-            // tweaked in central. see below.
-            let mut canonical_name = fqdn.clone();
-            let mut member_is_named = false;
-            let mut ptr_name = fqdn.clone();
-
-            if let Some(name) = parse_member_name(member.name.clone(), self.domain_name.clone()) {
-                canonical_name = name.clone();
-                ptr_name = name;
-                member_is_named = true;
-            }
-
-            let ips: Vec<IpAddr> = member
-                .config
-                .expect("Member config does not exist")
-                .ip_assignments
-                .expect("IP assignments for member do not exist")
-                .into_iter()
-                .map(|s| IpAddr::from_str(&s).expect("Could not parse IP address"))
-                .collect();
-
-            let wildcard = Name::from_str("*")?;
-
-            self.match_or_insert(fqdn.clone(), ips.clone());
-
-            if self.wildcard_everything {
-                let wildcard = wildcard.clone().append_name(&fqdn).into_wildcard();
-                records.push(wildcard.clone());
-                self.match_or_insert(wildcard, ips.clone());
-            }
-
-            if member_is_named {
-                self.match_or_insert(canonical_name.clone(), ips.clone());
-                if self.wildcard_everything {
-                    let wildcard = wildcard.append_name(&canonical_name).into_wildcard();
-                    records.push(wildcard.clone());
-                    self.match_or_insert(wildcard, ips.clone())
-                }
-            }
-
-            if let Some(local_ptr_authority) = self.ptr_authority.to_owned() {
-                for ip in ips.clone() {
-                    records.push(ip.into_name().expect("Could not coerce IP into name"));
-                    configure_ptr(local_ptr_authority.clone(), ip, ptr_name.clone())?;
-                }
-            }
-
-            records.push(fqdn.clone());
-            records.push(canonical_name.clone());
+            let record =
+                ZTRecord::new(&member, self.domain_name.clone(), self.wildcard_everything)?;
+            record.insert_member(self)?;
+            record.insert_member_ptr(&self.ptr_authority, &mut records)?;
+            record.insert(&mut records);
         }
 
         prune_records(self.authority.to_owned(), records.clone())?;

--- a/src/authority/tests.rs
+++ b/src/authority/tests.rs
@@ -34,6 +34,7 @@ struct Service {
     runtime: Arc<Mutex<Runtime>>,
     tn: Arc<TestNetwork>,
     resolvers: Arc<Vec<Arc<Resolver>>>,
+    update_interval: Option<Duration>,
     pub listen_ips: Vec<String>,
     pub listen_cidrs: Vec<String>,
 }
@@ -72,6 +73,7 @@ fn create_listeners(
     tn: &TestNetwork,
     hosts: HostsType,
     update_interval: Option<Duration>,
+    wildcard_everything: bool,
 ) -> (Vec<String>, Vec<String>) {
     let listen_cidrs = runtime
         .lock()
@@ -101,7 +103,7 @@ fn create_listeners(
         if !authority_map.contains_key(&cidr.network()) {
             let ptr_authority = new_ptr_authority(cidr).unwrap();
 
-            let ztauthority = init_authority(
+            let mut ztauthority = init_authority(
                 ptr_authority,
                 tn.token(),
                 tn.network.clone().id.unwrap(),
@@ -114,6 +116,10 @@ fn create_listeners(
                 update_interval.unwrap_or(Duration::new(30, 0)),
                 authority.clone(),
             );
+
+            if wildcard_everything {
+                ztauthority.wildcard_everything();
+            }
 
             let arc_authority = Arc::new(tokio::sync::RwLock::new(ztauthority));
             authority_map.insert(cidr.network(), arc_authority.to_owned());
@@ -184,7 +190,12 @@ fn create_resolvers(ips: Vec<String>) -> Vec<Arc<Resolver>> {
 }
 
 impl Service {
-    fn new(hosts: HostsType, update_interval: Option<Duration>, ips: Option<Vec<&str>>) -> Self {
+    fn new(
+        hosts: HostsType,
+        update_interval: Option<Duration>,
+        ips: Option<Vec<&str>>,
+        wildcard_everything: bool,
+    ) -> Self {
         let runtime = init_test_runtime();
 
         let tn = if let Some(ips) = ips {
@@ -199,8 +210,13 @@ impl Service {
             TestNetwork::new(runtime.clone(), "basic-ipv4", &mut TestContext::default()).unwrap()
         };
 
-        let (listen_cidrs, listen_ips) =
-            create_listeners(runtime.clone(), &tn, hosts, update_interval);
+        let (listen_cidrs, listen_ips) = create_listeners(
+            runtime.clone(),
+            &tn,
+            hosts,
+            update_interval,
+            wildcard_everything,
+        );
 
         Self {
             runtime,
@@ -208,17 +224,21 @@ impl Service {
             listen_ips: listen_ips.clone(),
             listen_cidrs,
             resolvers: Arc::new(create_resolvers(listen_ips)),
+            update_interval,
         }
     }
 
-    #[allow(dead_code)]
-    pub fn any_listen_ip(&self) -> String {
-        self.listen_ips
-            .clone()
-            .into_iter()
-            .choose(&mut rand::thread_rng())
-            .unwrap()
-            .clone()
+    pub fn any_listen_ip(&self) -> Ipv4Addr {
+        Ipv4Addr::from_str(
+            &self
+                .listen_ips
+                .clone()
+                .into_iter()
+                .choose(&mut rand::thread_rng())
+                .unwrap()
+                .clone(),
+        )
+        .unwrap()
     }
 
     pub fn runtime(&self) -> Arc<Mutex<Runtime>> {
@@ -248,14 +268,91 @@ impl Service {
     pub fn lookup_ptr(self, record: String) -> Vec<String> {
         self.any_resolver().lookup_ptr(record)
     }
+
+    pub fn member_record(&self) -> String {
+        format!("zt-{}.domain.", self.network().identity().clone())
+    }
+
+    pub fn change_name(&self, name: &'static str) {
+        let mut member = self
+            .runtime()
+            .lock()
+            .unwrap()
+            .block_on(
+                zerotier_central_api::apis::network_member_api::get_network_member(
+                    &self.network().central(),
+                    &self.network().network.clone().id.unwrap(),
+                    &self.network().identity(),
+                ),
+            )
+            .unwrap();
+
+        member.name = Some(name.to_string());
+
+        self.runtime()
+            .lock()
+            .unwrap()
+            .block_on(
+                zerotier_central_api::apis::network_member_api::update_network_member(
+                    &self.network().central(),
+                    &self.network().network.clone().id.unwrap(),
+                    &self.network().identity(),
+                    member,
+                ),
+            )
+            .unwrap();
+
+        if self.update_interval.is_some() {
+            thread::sleep(self.update_interval.unwrap()); // wait for it to update
+        }
+    }
 }
 
 #[test]
 #[ignore]
-fn test_01_hosts_file_reloading() {
+fn test_wildcard_ipv4_central() {
+    let service = Service::new(HostsType::None, Some(Duration::new(1, 0)), None, true);
+
+    let member_record = service.member_record();
+    let named_record = Name::from_str("islay.domain.").unwrap();
+
+    service.change_name("islay");
+
+    assert_eq!(
+        service.lookup_a(named_record.to_string()).first().unwrap(),
+        &service.any_listen_ip(),
+    );
+
+    assert_eq!(
+        service.lookup_a(member_record.to_string()).first().unwrap(),
+        &service.any_listen_ip(),
+    );
+
+    for host in vec!["one", "ten", "zt-foo", "another-record"] {
+        for rec in vec![named_record.to_string(), member_record.clone()] {
+            let lookup = Name::from_str(&host)
+                .unwrap()
+                .append_domain(&Name::from_str(&rec).unwrap())
+                .to_string();
+            assert_eq!(
+                service.lookup_a(lookup).first().unwrap(),
+                &service.any_listen_ip()
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn test_hosts_file_reloading() {
     let hosts_path = "/tmp/zeronsd-test-hosts";
     std::fs::write(hosts_path, "127.0.0.2 islay\n").unwrap();
-    let service = Service::new(HostsType::Path(hosts_path), Some(Duration::new(1, 0)), None);
+    let service = Service::new(
+        HostsType::Path(hosts_path),
+        Some(Duration::new(1, 0)),
+        None,
+        false,
+    );
 
     assert_eq!(
         service
@@ -284,9 +381,10 @@ fn test_battery_single_domain() {
         HostsType::None,
         None,
         Some(vec!["172.16.240.2", "172.16.240.3", "172.16.240.4"]),
+        false,
     );
 
-    let record = format!("zt-{}.domain.", service.network().identity().clone());
+    let record = service.member_record();
 
     eprintln!("Looking up {}", record);
     let mut listen_ips = service.listen_ips.clone();
@@ -370,9 +468,9 @@ fn test_battery_single_domain() {
 #[ignore]
 fn test_battery_multi_domain_hosts_file() {
     let ips = vec!["172.16.240.2", "172.16.240.3", "172.16.240.4"];
-    let service = Service::new(HostsType::Fixture("basic"), None, Some(ips.clone()));
+    let service = Service::new(HostsType::Fixture("basic"), None, Some(ips.clone()), false);
 
-    let record = format!("zt-{}.domain.", service.network().identity().clone());
+    let record = service.member_record();
 
     eprintln!("Looking up random domains");
 
@@ -409,39 +507,11 @@ fn test_battery_single_domain_named() {
         HostsType::None,
         Some(update_interval),
         Some(vec!["172.16.240.2", "172.16.240.3", "172.16.240.4"]),
+        false,
     );
-    let member_record = format!("zt-{}.domain.", service.network().identity().clone());
+    let member_record = service.member_record();
 
-    let mut member = service
-        .runtime()
-        .lock()
-        .unwrap()
-        .block_on(
-            zerotier_central_api::apis::network_member_api::get_network_member(
-                &service.network().central(),
-                &service.network().network.clone().id.unwrap(),
-                &service.network().identity(),
-            ),
-        )
-        .unwrap();
-
-    member.name = Some("islay".to_string());
-
-    service
-        .runtime()
-        .lock()
-        .unwrap()
-        .block_on(
-            zerotier_central_api::apis::network_member_api::update_network_member(
-                &service.network().central(),
-                &service.network().network.clone().id.unwrap(),
-                &service.network().identity(),
-                member,
-            ),
-        )
-        .unwrap();
-
-    thread::sleep(update_interval); // wait for it to update
+    service.change_name("islay");
 
     let named_record = "islay.domain.".to_string();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn write_help(app: clap::App) -> Result<(), anyhow::Error> {
 }
 
 fn unsupervise(network: Option<&str>) -> Result<(), anyhow::Error> {
-    supervise::Properties::new(None, network, None, None, None)?.uninstall_supervisor()
+    supervise::Properties::new(None, network, None, None, None, false)?.uninstall_supervisor()
 }
 
 fn supervise(
@@ -42,8 +42,17 @@ fn supervise(
     hosts_file: Option<&str>,
     authtoken: Option<&str>,
     token: Option<&str>,
+    wildcard_names: bool,
 ) -> Result<(), anyhow::Error> {
-    supervise::Properties::new(domain, network, hosts_file, authtoken, token)?.install_supervisor()
+    supervise::Properties::new(
+        domain,
+        network,
+        hosts_file,
+        authtoken,
+        token,
+        wildcard_names,
+    )?
+    .install_supervisor()
 }
 
 fn start(
@@ -175,6 +184,7 @@ fn main() -> Result<(), anyhow::Error> {
             (@arg file: -f --file +takes_value "An additional lists of hosts in /etc/hosts format")
             (@arg secret_file: -s --secret +takes_value "Path to authtoken.secret (usually detected)")
             (@arg token_file: -t --token +takes_value +required "Path to a file containing the ZeroTier Central token; this file must not be moved")
+            (@arg wildcard: -w --wildcard "Wildcard all names in Central to point at the respective member's IP address(es)")
             (@arg NETWORK_ID: +required "Network ID to query")
         )
         (@subcommand unsupervise =>
@@ -206,6 +216,7 @@ fn main() -> Result<(), anyhow::Error> {
             args.value_of("file"),
             args.value_of("secret_file"),
             args.value_of("token_file"),
+            args.is_present("wildcard"),
         )?,
         "unsupervise" => unsupervise(args.value_of("NETWORK_ID"))?,
         _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ fn main() -> Result<(), anyhow::Error> {
             (@arg file: -f --file +takes_value "An additional lists of hosts in /etc/hosts format")
             (@arg secret_file: -s --secret +takes_value "Path to authtoken.secret (usually detected)")
             (@arg token_file: -t --token +takes_value "Path to a file containing the ZeroTier Central token")
-            (@arg wildcard_names: -w --wildcard-names "Wildcard all names in Central to point at the respective member's IP address(es)")
+            (@arg wildcard: -w --wildcard "Wildcard all names in Central to point at the respective member's IP address(es)")
             (@arg NETWORK_ID: +required "Network ID to query")
         )
         (@subcommand supervise =>
@@ -198,7 +198,7 @@ fn main() -> Result<(), anyhow::Error> {
             args.value_of("file"),
             args.value_of("secret_file"),
             args.value_of("token_file"),
-            args.is_present("wildcard_names"),
+            args.is_present("wildcard"),
         )?,
         "supervise" => supervise(
             args.value_of("domain"),

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -14,7 +14,7 @@ After=zerotier-one.service
 
 [Service]
 Type=simple
-ExecStart={binpath} start -t {token} {{ if authtoken }}-s {authtoken} {{endif}}{{ if hosts_file }}-f {hosts_file} {{ endif }}{{ if domain }}-d {domain} {{ endif }}{network}
+ExecStart={binpath} start -t {token} {{ if wildcard_names }}-w {{endif}}{{ if authtoken }}-s {authtoken} {{endif}}{{ if hosts_file }}-f {hosts_file} {{ endif }}{{ if domain }}-d {domain} {{ endif }}{network}
 TimeoutStopSec=30
 
 [Install]
@@ -29,11 +29,13 @@ pub struct Properties {
     pub hosts_file: Option<String>,
     pub authtoken: Option<String>,
     pub token: String,
+    pub wildcard_names: bool,
 }
 
 impl Default for Properties {
     fn default() -> Self {
         Self {
+            wildcard_names: false,
             binpath: String::from("zeronsd"),
             domain: None,
             network: String::new(),
@@ -51,8 +53,10 @@ impl<'a> Properties {
         hosts_file: Option<&'a str>,
         authtoken: Option<&'a str>,
         token: Option<&'a str>,
+        wildcard_names: bool,
     ) -> Result<Self, anyhow::Error> {
         Ok(Self {
+            wildcard_names,
             binpath: String::from(std::env::current_exe()?.to_string_lossy()),
             // make this garbage a macro later
             domain: match domain {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -138,6 +138,7 @@ fn test_supervise_systemd_green() {
                 domain: Some(String::from("zerotier")),
                 authtoken: Some(String::from("/var/lib/zerotier-one/authtoken.secret")),
                 hosts_file: Some(String::from("/etc/hosts")),
+                wildcard_names: true,
             },
         ),
     ];

--- a/testdata/supervise/systemd/with-filled-in-properties.unit
+++ b/testdata/supervise/systemd/with-filled-in-properties.unit
@@ -6,7 +6,7 @@ After=zerotier-one.service
 
 [Service]
 Type=simple
-ExecStart=zeronsd start -t /proc/cpuinfo -s /var/lib/zerotier-one/authtoken.secret -f /etc/hosts -d zerotier 1234567891011121
+ExecStart=zeronsd start -t /proc/cpuinfo -w -s /var/lib/zerotier-one/authtoken.secret -f /etc/hosts -d zerotier 1234567891011121
 TimeoutStopSec=30
 
 [Install]


### PR DESCRIPTION
This enables wildcard support via the `-w` flag to `zeronsd start`. What "wildcard support" means is that it will append wildcards to every member "record" in the catalog; these are the `zt-` names as well as the names calculated from the member `name` field.