### PR TITLE
Add `supervise` for macos.

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -160,17 +160,17 @@ fn test_supervise_systemd_green() {
             assert!(path.is_ok(), "{}", name);
             let expected = std::fs::read_to_string(path.unwrap());
             assert!(expected.is_ok(), "{}", name);
-            let testing = props.systemd_template();
+            let testing = props.supervise_template();
             assert!(testing.is_ok(), "{}", name);
 
             assert_eq!(testing.unwrap(), expected.unwrap(), "{}", name);
         } else {
             assert!(props.validate().is_ok(), "{}", name);
 
-            let template = props.systemd_template();
+            let template = props.supervise_template();
             assert!(template.is_ok(), "{}", name);
             assert!(
-                std::fs::write(path, props.systemd_template().unwrap()).is_ok(),
+                std::fs::write(path, props.supervise_template().unwrap()).is_ok(),
                 "{}",
                 name
             );


### PR DESCRIPTION
For issue #43
It creates a plist that the user can load/unload with
launchctl. It's the same type of thing as the
systemd unit file.

```
travis@tl-zt zeronsd % sudo ./target/debug/zeronsd supervise -t .token -d test-domain -w -f ./hosts -s .authtoken c7c8172af18362e9
Password:
INFO - Service definition written to /Library/LaunchDaemons/com.zerotier.nsd.c7c8172af18362e9.plist.
To start the service, run:
sudo launchctl load /Library/LaunchDaemons/com.zerotier.nsd.c7c8172af18362e9.plist
```

```
cat /Library/LaunchDaemons/com.zerotier.nsd.c7c8172af18362e9.plist

<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
    <key>Label</key> <string>com.zerotier.nsd.c7c8172af18362e9</string>

    <key>ProgramArguments</key>
    <array>
      <string>/Users/travis/repos/github.com/zerotier/zeronsd/./target/debug/zeronsd</string>
      <string>start</string>
      <string>-t</string>
      <string>/Users/travis/repos/github.com/zerotier/zeronsd/.token</string>

      <string>-w</string>

      <string>-s</string>
      <string>/Users/travis/repos/github.com/zerotier/zeronsd/.authtoken</string>

      <string>-f</string>
      <string>/Users/travis/repos/github.com/zerotier/zeronsd/hosts</string>

      <string>-d</string>
      <string>test-domain</string>

      <string>c7c8172af18362e9</string>
    </array>

    <key>UserName</key> <string>root</string>

    <key>RunAtLoad</key> <true/>

    <key>KeepAlive</key> <true/>

    <key>StandardErrorPath</key> <string>/var/log/zerotier/nsd/c7c8172af18362e9.err</string>
    <key>StandardOutPath</key> <string>/var/log/zerotier/nsd/c7c8172af18362e9.log</string>

  </dict>
    </plist>
```

```
travis@tl-zt zeronsd % sudo launchctl load /Library/LaunchDaemons/com.zerotier.nsd.c7c8172af18362e9.plist
travis@tl-zt zeronsd % host abcd.zt-2f2fda62e9.test-domain 172.28.254.142
Using domain server:
Name: 172.28.254.142
Address: 172.28.254.142#53
Aliases:

abcd.zt-2f2fda62e9.test-domain has address 172.28.254.142
Host abcd.zt-2f2fda62e9.test-domain not found: 3(NXDOMAIN)
Host abcd.zt-2f2fda62e9.test-domain not found: 3(NXDOMAIN)
```