### PR TITLE
Update nameserver record in DNS without CIDR network portion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,9 @@ fn start(args: &clap::ArgMatches<'_>) -> Result<(), anyhow::Error> {
             update_central_dns(
                 runtime,
                 domain_name.clone(),
-                ips.clone(),
+                ips.iter()
+                    .map(|i| utils::parse_ip_from_cidr(i.clone()).to_string())
+                    .collect(),
                 token.clone(),
                 network_id.clone(),
             )?;


### PR DESCRIPTION
This regressed in 0.2.x.

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>