### PR TITLE
Explain how to get host completion.

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -49,7 +49,7 @@ Try this: https://blog.sanctum.geek.nz/bash-hostname-completion/
 ## Problems
 - This will get progressively slower with the size of your networks.
 - You must be joined to the zerotier network with the dns server (and on Mac have allowDNS enabled) . You'll get "host not found".
-- The DNS server must be up.
+- All of the DNS servers must be up, or the script will take a long time.
 - sourcing .zshrc appends and doesn't clear the list of hosts. You need to close the shell and open a new one.
 
 ## Run nmap manually, without the script, if needed

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -4,7 +4,7 @@ Comments and pull requests welcome.
 You _don't_ need to be the admin of the network or of the zeronsd server.
 
 - We use `nmap -sL` to list all the hostnames on a ZeroTier subnet.
-- Write the names to files somewhere like ~/.config/hosts-$NETWORK_ID.
+- Write the names to files somewhere like ~/.hosts-$NETWORK_ID.
 - Tell zsh or bash to use these files for host completion.
 
 ## (linux only) copy the zerotier authtoken.secret to your home directory. 
@@ -24,7 +24,7 @@ The script depends on `jq` and `nmap`.
 - `brew install jq nmap` or `apt install jq nmap` if you don't have them.
 - `mkdir -p $HOME/.config/zeronsd`
 - `chmod +x get-zeronsd-host-names.sh`
-- `./get-zeronsd-host-names.sh ~/.config/zeronsd`
+- `./get-zeronsd-host-names.sh
 
 ## Setup your shell to use the hosts
 ### zsh
@@ -39,12 +39,18 @@ If you know a better way, let us know.
 zstyle -s ':completion:*:hosts' hosts _hosts_config
 
 # append hosts from zeronsd
-[[ -r ~/.completion ]] && _hosts_config+=($(cat $HOME/.config/zeronsd/hosts-*))
+[[ -r ~/.hosts ]] && _hosts_config+=($(cat $HOME/.hosts/hosts-*))
 zstyle ':completion:*:hosts' hosts $_hosts_config
 ```
 
 ### bash
 Try this: https://blog.sanctum.geek.nz/bash-hostname-completion/
+
+## Problems
+- This will get progressively slower with the size of your networks.
+- You must be joined to the zerotier network with the dns server (and on Mac have allowDNS enabled) . You'll get "host not found".
+- The DNS server must be up.
+- sourcing .zshrc appends and doesn't clear the list of hosts. You need to close the shell and open a new one.
 
 ## Run nmap manually, without the script, if needed
 Depending on your network setups, this may or may not fail. It's a rough shell script.

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,66 @@
+# Shell completion of host names
+A quick and dirty way to get autocompletion of your zeronsd hostnames.
+Comments and pull requests welcome.
+You _don't_ need to be the admin of the network or of the zeronsd server.
+
+- We use `nmap -sL` to list all the hostnames on a ZeroTier subnet.
+- Write the names to files somewhere like ~/.config/hosts-$NETWORK_ID.
+- Tell zsh or bash to use these files for host completion.
+
+## (linux only) copy the zerotier authtoken.secret to your home directory. 
+This lets you use zerotier-cli without sudo. 
+On macOS the installer does this for you.
+
+``` sh
+sudo cp /var/lib/zerotier-one/authtoken.secret ~/.zeroTierOneAuthToken
+sudo chown $(id -u):$(id -g) ~/.zeroTierOneAuthToken
+```
+
+## Run the script
+The script will query your local zerotier-one for networks with DNS servers configured and create a file for each network.
+
+The script depends on `jq` and `nmap`.
+
+- `brew install jq nmap` or `apt install jq nmap` if you don't have them.
+- `mkdir -p $HOME/.config/zeronsd`
+- `chmod +x get-zeronsd-host-names.sh`
+- `./get-zeronsd-host-names.sh ~/.config/zeronsd`
+
+## Setup your shell to use the hosts
+### zsh
+Put this in your ~/.zshrc 
+
+You may need to adapt it to your setup.
+
+If you know a better way, let us know.
+
+```sh
+# get current hosts. zsh builtin stuff uses /etc/hosts, ~/.ssh/known_hosts, etc...
+zstyle -s ':completion:*:hosts' hosts _hosts_config
+
+# append hosts from zeronsd
+[[ -r ~/.completion ]] && _hosts_config+=($(cat $HOME/.config/zeronsd/hosts-*))
+zstyle ':completion:*:hosts' hosts $_hosts_config
+```
+
+### bash
+Try this: https://blog.sanctum.geek.nz/bash-hostname-completion/
+
+## Run nmap manually, without the script, if needed
+Depending on your network setups, this may or may not fail. It's a rough shell script.
+
+If you need to run it manually, it's basically:
+
+`nmap -sL $SUBNET -oG - --dns-server=$SERVER | grep -v "()" | grep Host:  | cut -d "(" -f2 | cut -d ")" -f1 > $OUTDIR/hosts-$NETWORK_ID`
+
+Where:
+- $SUBNET :: Managed Route for the ZeroTier Network. For example: "10.147.20.0/24"
+- $SERVER :: One of your zeronsd servers for this ZeroTier network. For example: "10.147.20.3"
+- $NETWORK_ID :: The ZeroTier Network ID.
+
+It's a small script. Edit it to your needs.
+
+## Getting the script?
+For now...
+If you're reading this on github, click on the script then on "raw".
+Then you can copy and paste it, or curl it from the current url, to somewhere like ~/bin/get-zeronsd-host-names.sh

--- a/contrib/get-zeronsd-host-names.sh
+++ b/contrib/get-zeronsd-host-names.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+    echo "Please provide the output directory"
+    echo "Like: get-zeronsd-host-names.sh ~/.config/zeronsd"
+    exit 1
+fi
+
+
+OUTDIR=$1
+
+# Get list of Network IDs that have DNS enabled
+NWIDS=$(zerotier-cli listnetworks -j | jq -r ".[] | select(.allowDNS == true) | .id")
+
+for NWID in $NWIDS
+do
+    # get one of the DNS server addresses
+    SERVER=$(zerotier-cli listnetworks -j | jq -r ".[] | select(.id == \"$NWID\") | .dns | .servers[0]")
+
+    # Get the subnet/cidr of the zerotier network
+    SUBNET=$(zerotier-cli listnetworks -j | jq -r ".[] | select(.id == \"$NWID\") | .routes | .[] | select(.via == null) | .target")
+
+    # scan each network with nmap and output names to file in $OUTDIR
+    nmap -sL $SUBNET -oG - --dns-server=$SERVER | grep -v "()" | grep Host:  | cut -d "(" -f2 | cut -d ")" -f1 > $OUTDIR/hosts-$NWID
+
+    # echo "Wrote host names to: $OUTDIR/hosts-$NWID"
+done

--- a/contrib/get-zeronsd-host-names.sh
+++ b/contrib/get-zeronsd-host-names.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ $# -eq 0 ]; then
-    echo "Please provide the output directory"
-    echo "Like: get-zeronsd-host-names.sh ~/.config/zeronsd"
-    exit 1
+
+# use $HOME/hosts/ as the directory, unless user specifies something else
+if [ $# -eq 0 ];
+then
+    OUTDIR="$HOME/.hosts"
+else
+    OUTDIR=$1
 fi
-
-
-OUTDIR=$1
 
 # Get list of Network IDs that have DNS enabled
 NWIDS=$(zerotier-cli listnetworks -j | jq -r ".[] | select(.dns.servers?) | .id")
+
+mkdir -p $OUTDIR
+
+# clear hosts from old, unjoined zerotier networks
+# rm -f $OUTDIR/hosts*
 
 for NWID in $NWIDS
 do


### PR DESCRIPTION
Re issue #91

Just wanted to get something out there where people might find it. Let me know if it's too rough. I was shooting for more of a "here's a thing you can do" rather than "here's a tool that will do a thing for you." 

Annoyances I've noticed so far:
- If you leave a network, you get still completions for that network, unless you remember to delete the file for that network. 
- Making sure zshrc config and the script match (location of host-$id files)