### PR TITLE
When replacing the record, don't try to edit it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,11 @@ test:
 	cargo test
 
 test-integration:
+ifneq (${SKIP},)
+	TOKEN=$$(cat test-token.txt) sudo -E bash -c "$$(which cargo) test --features integration-tests -j1 -- --skip '${SKIP}' --nocapture --test-threads 1"
+else
 	TOKEN=$$(cat test-token.txt) sudo -E bash -c "$$(which cargo) test --features integration-tests -j1 -- --nocapture --test-threads 1"
+endif
 
 generate: central service
 


### PR DESCRIPTION
This bug is caused by the following scenario:

- Create two members, each with a name like `test1` and `test2`.
- Rename it so that `test1` is now `test2`, and `test2` is now `test1`
- Now, after zeronsd updates, each record will have two ip addresses,
  both the same list.

This was caused by the rename causing it being added to a whitelist
where it was edited, not replaced, therefore appending to the list. This
was a design mistake in general and some additional work will be done to
correct this in a refactoring pass.

The new behavior is to replace the recordset entirely, which is probably
much more correct in DNS terms anyway.

closes #94 (thanks @laduke for the report!)

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>