### PR TITLE
Cargo.toml general cleanups, move to rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,9 @@ homepage = "https://github.com/zerotier/zeronsd"
 repository = "https://github.com/zerotier/zeronsd"
 documentation = "https://github.com/zerotier/zeronsd/blob/main/README.md"
 license = "BSD-3-Clause"
-license-file = "LICENSE"
 readme = "README.md"
 keywords = ["dns", "zerotier"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Signed-off-by: Erik Hollensbe <linux@hollensbe.org>