### PR TITLE
Alpine supervision

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,18 +6,22 @@
 #   zeronsd:alpine start -s /authtoken.secret -t /token.txt \
 #   <network id>
 
-FROM alpine:latest
-
-COPY . /zeronsd
-WORKDIR /zeronsd
+FROM alpine:latest as builder
 
 RUN apk add rust
 RUN apk add cargo
 RUN apk add openssl
 RUN apk add openssl-dev
 
+COPY . /zeronsd
+WORKDIR /zeronsd
+
 RUN cargo install --path .
 
-ENV PATH /root/.cargo/bin
+FROM alpine:latest
+
+RUN apk add openssl ca-certificates libgcc
+
+COPY --from=builder /root/.cargo/bin/zeronsd /bin/zeronsd
 
 ENTRYPOINT ["zeronsd"]

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use anyhow::anyhow;
 use log::info;
+use regex::Regex;
 use serde::Serialize;
 use tinytemplate::TinyTemplate;
 use trust_dns_resolver::Name;
@@ -16,9 +17,11 @@ const SERVICE_TEMPLATE: &str = "";
 
 #[cfg(target_os = "linux")]
 const SUPERVISE_SYSTEM_DIR: &str = "/lib/systemd/system";
+#[cfg(target_os = "linux")]
+const OS_RELEASE_FILE: &str = "/etc/os-release";
 
 #[cfg(target_os = "linux")]
-const SERVICE_TEMPLATE: &str = "
+const SYSTEMD_TEMPLATE: &str = "
 [Unit]
 Description=zeronsd for network {network}
 Requires=zerotier-one.service
@@ -32,6 +35,24 @@ TimeoutStopSec=30
 [Install]
 WantedBy=default.target
 ";
+
+#[cfg(target_os = "linux")]
+const ALPINE_INIT_DIR: &str = "/etc/init.d";
+#[cfg(target_os = "linux")]
+const ALPINE_TEMPLATE: &str = r#"
+#!/sbin/openrc-run
+
+depend() \{
+    need zerotier-one
+    use network dns logger netmount
+}
+
+description="zeronsd for network {network}"
+command="{binpath}"
+command_args="start -t {token} {{ if wildcard_names }}-w {{endif}}{{ if authtoken }}-s {authtoken} {{endif}}{{ if hosts_file }}-f {hosts_file} {{ endif }}{{ if domain }}-d {domain} {{ endif }}{network}"
+command_background="yes"
+pidfile="/run/$RC_SVCNAME.pid"
+"#;
 
 #[cfg(target_os = "macos")]
 const SUPERVISE_SYSTEM_DIR: &str = "/Library/LaunchDaemons/";
@@ -219,13 +240,36 @@ impl<'a> Properties {
         Ok(())
     }
 
-    pub fn supervise_template(&self) -> Result<String, anyhow::Error> {
+    pub fn supervise_template(&self, distro: Option<&str>) -> Result<String, anyhow::Error> {
+        let template = self.get_service_template(distro);
+
         let mut t = TinyTemplate::new();
-        t.add_template("supervise", SERVICE_TEMPLATE)?;
+        t.add_template("supervise", template)?;
         match t.render("supervise", self) {
             Ok(x) => Ok(x),
             Err(e) => Err(anyhow!(e)),
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn get_service_template(&self, distro: Option<&str>) -> &str {
+        match distro {
+            Some(s) => match s {
+                "alpine" => ALPINE_TEMPLATE,
+                _ => SYSTEMD_TEMPLATE,
+            },
+            None => SYSTEMD_TEMPLATE,
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    fn get_service_template(&self, distro: Option<&str>) -> &str {
+        return SERVICE_TEMPLATE;
+    }
+
+    #[cfg(target_os = "macos")]
+    fn get_service_template(&self, distro: Option<&str>) -> &str {
+        return SERVICE_TEMPLATE;
     }
 
     #[cfg(target_os = "windows")]
@@ -234,8 +278,14 @@ impl<'a> Properties {
     }
 
     #[cfg(target_os = "linux")]
-    fn service_name(&self) -> String {
-        format!("zeronsd-{}.service", self.network)
+    fn service_name(&self, distro: Option<&str>) -> String {
+        match distro {
+            Some(s) => match s {
+                "alpine" => format!("zeronsd-{}", self.network),
+                _ => format!("zeronsd-{}.service", self.network),
+            },
+            None => format!("zeronsd-{}.service", self.network),
+        }
     }
 
     #[cfg(target_os = "macos")]
@@ -243,38 +293,73 @@ impl<'a> Properties {
         format!("com.zerotier.nsd.{}.plist", self.network)
     }
 
-    fn service_path(&self) -> PathBuf {
-        PathBuf::from(SUPERVISE_SYSTEM_DIR).join(self.service_name())
+    fn service_path(&self, distro: Option<&str>) -> PathBuf {
+        let dir = match distro {
+            Some(s) => match s {
+                "alpine" => ALPINE_INIT_DIR,
+                _ => SUPERVISE_SYSTEM_DIR,
+            },
+            None => SUPERVISE_SYSTEM_DIR,
+        };
+        PathBuf::from(dir).join(self.service_name(distro))
     }
 
     pub fn install_supervisor(&mut self) -> Result<(), anyhow::Error> {
         self.validate()?;
 
         if cfg!(target_os = "linux") {
-            let template = self.supervise_template()?;
-            let service_path = self.service_path();
+            if let Ok(release) = std::fs::read_to_string(OS_RELEASE_FILE) {
+                let id_regex = Regex::new(r#"\nID=(.+)\n"#)?;
+                if let Some(caps) = id_regex.captures(&release) {
+                    if let Some(distro) = caps.get(1) {
+                        let distro = Some(distro.as_str());
+                        let template = self.supervise_template(distro)?;
+                        let service_path = self.service_path(distro);
 
-            match std::fs::write(service_path.clone(), template) {
-                Ok(_) => {}
-                Err(e) => {
-                    return Err(anyhow!(
-                        "Could not write the template {}; are you root? ({})",
-                        service_path
-                            .to_str()
-                            .expect("Could not coerce service path to string"),
-                        e,
-                    ))
+                        match std::fs::write(service_path.clone(), template) {
+                            Ok(_) => {}
+                            Err(e) => {
+                                return Err(anyhow!(
+                                    "Could not write the template {}; are you root? ({})",
+                                    service_path
+                                        .to_str()
+                                        .expect("Could not coerce service path to string"),
+                                    e,
+                                ))
+                            }
+                        };
+
+                        let systemd_help = format!("Don't forget to `systemctl daemon-reload`, `systemctl enable zeronsd-{}` and `systemctl start zeronsd-{}`.", self.network, self.network);
+                        let alpine_help = format!(
+                            "Don't to `rc-update add zeronsd-{}` and `rc-service start zeronsd-{}`",
+                            self.network, self.network
+                        );
+
+                        let help = match distro {
+                            Some(s) => match s {
+                                "alpine" => alpine_help,
+                                _ => systemd_help,
+                            },
+                            None => systemd_help,
+                        };
+
+                        info!(
+                            "Service definition written to {}.\n{}",
+                            service_path
+                                .to_str()
+                                .expect("Could not coerce service path to string"),
+                            help,
+                        );
+                    } else {
+                        return Err(anyhow!("Could not determine Linux distribution; you'll need to configure supervision manually. Sorry!"));
+                    }
+                } else {
+                    return Err(anyhow!("Could not determine Linux distribution; you'll need to configure supervision manually. Sorry!"));
                 }
-            };
-
-            info!(
-                "Service definition written to {}.\nDon't forget to `systemctl daemon-reload` and `systemctl enable zeronsd-{}`",
-                service_path.to_str().expect("Could not coerce service path to string"),
-                self.network,
-            );
+            }
         } else if cfg!(target_os = "macos") {
-            let template = self.supervise_template()?;
-            let service_path = self.service_path();
+            let template = self.supervise_template(None)?;
+            let service_path = self.service_path(None);
 
             match std::fs::write(service_path.clone(), template) {
                 Ok(_) => {}
@@ -302,12 +387,12 @@ impl<'a> Properties {
 
     pub fn uninstall_supervisor(&self) -> Result<(), anyhow::Error> {
         if cfg!(target_os = "linux") {
-            match std::fs::remove_file(self.service_path()) {
+            match std::fs::remove_file(self.service_path(None)) {
                 Ok(_) => {}
                 Err(e) => {
                     return Err(anyhow!(
                         "Could not uninstall supervisor unit file ({}): {}",
-                        self.service_path()
+                        self.service_path(None)
                             .to_str()
                             .expect("Could not coerce service path to string"),
                         e,
@@ -315,12 +400,12 @@ impl<'a> Properties {
                 }
             };
         } else if cfg!(target_os = "macos") {
-            match std::fs::remove_file(self.service_path()) {
+            match std::fs::remove_file(self.service_path(None)) {
                 Ok(_) => {}
                 Err(e) => {
                     return Err(anyhow!(
                         "Could not uninstall supervisor unit file ({}): {}",
-                        self.service_path()
+                        self.service_path(None)
                             .to_str()
                             .expect("Could not coerce service path to string"),
                         e,
@@ -330,8 +415,8 @@ impl<'a> Properties {
 
             info!(
                 "Service definition removed from {}.\nDon't forget to stop it:\nsudo launchctl remove {}",
-                self.service_path().to_str().expect("Could not coerce service path to string"),
-                self.service_name().replace(".plist", "")
+                self.service_path(None).to_str().expect("Could not coerce service path to string"),
+                self.service_name(None).replace(".plist", "")
             );
         } else {
             return Err(anyhow!("Your platform is not supported for this command"));

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -346,7 +346,7 @@ impl<'a> Properties {
 
                         let systemd_help = format!("Don't forget to `systemctl daemon-reload`, `systemctl enable zeronsd-{}` and `systemctl start zeronsd-{}`.", self.network, self.network);
                         let alpine_help = format!(
-                            "Don't to `rc-update add zeronsd-{}` and `rc-service start zeronsd-{}`",
+                            "Don't to `rc-update add zeronsd-{}` and `rc-service zeronsd-{} start`",
                             self.network, self.network
                         );
 

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -113,6 +113,7 @@ pub struct Properties {
     pub authtoken: Option<String>,
     pub token: String,
     pub wildcard_names: bool,
+    distro: Option<String>,
 }
 
 impl From<&clap::ArgMatches<'_>> for Properties {
@@ -139,6 +140,7 @@ impl Default for Properties {
             hosts_file: None,
             authtoken: None,
             token: String::new(),
+            distro: None,
         }
     }
 }
@@ -152,7 +154,27 @@ impl<'a> Properties {
         token: Option<&'_ str>,
         wildcard_names: bool,
     ) -> Result<Self, anyhow::Error> {
+        let distro = if cfg!(target_os = "linux") {
+            if let Ok(release) = std::fs::read_to_string(OS_RELEASE_FILE) {
+                let id_regex = Regex::new(r#"\nID=(.+)\n"#)?;
+                if let Some(caps) = id_regex.captures(&release) {
+                    if let Some(distro) = caps.get(1) {
+                        Some(distro.clone().as_str().to_string())
+                    } else {
+                        None
+                    }
+                } else {
+                    return Err(anyhow!("Could not determine Linux distribution; you'll need to configure supervision manually. Sorry!"));
+                }
+            } else {
+                return Err(anyhow!("Could not determine Linux distribution; you'll need to configure supervision manually. Sorry!"));
+            }
+        } else {
+            None
+        };
+
         Ok(Self {
+            distro,
             wildcard_names,
             binpath: String::from(std::env::current_exe()?.to_string_lossy()),
             // make this garbage a macro later
@@ -243,8 +265,8 @@ impl<'a> Properties {
         Ok(())
     }
 
-    pub fn supervise_template(&self, distro: Option<&str>) -> Result<String, anyhow::Error> {
-        let template = self.get_service_template(distro);
+    pub fn supervise_template(&self) -> Result<String, anyhow::Error> {
+        let template = self.get_service_template();
 
         let mut t = TinyTemplate::new();
         t.add_template("supervise", template)?;
@@ -255,9 +277,9 @@ impl<'a> Properties {
     }
 
     #[cfg(target_os = "linux")]
-    fn get_service_template(&self, distro: Option<&str>) -> &str {
-        match distro {
-            Some(s) => match s {
+    fn get_service_template(&self) -> &str {
+        match self.distro.clone() {
+            Some(s) => match s.as_str() {
                 "alpine" => ALPINE_TEMPLATE.trim(),
                 _ => SYSTEMD_TEMPLATE,
             },
@@ -266,12 +288,12 @@ impl<'a> Properties {
     }
 
     #[cfg(target_os = "windows")]
-    fn get_service_template(&self, distro: Option<&str>) -> &str {
+    fn get_service_template(&self) -> &str {
         return SERVICE_TEMPLATE;
     }
 
     #[cfg(target_os = "macos")]
-    fn get_service_template(&self, distro: Option<&str>) -> &str {
+    fn get_service_template(&self) -> &str {
         return SERVICE_TEMPLATE;
     }
 
@@ -281,9 +303,9 @@ impl<'a> Properties {
     }
 
     #[cfg(target_os = "linux")]
-    fn service_name(&self, distro: Option<&str>) -> String {
-        match distro {
-            Some(s) => match s {
+    fn service_name(&self) -> String {
+        match self.distro.clone() {
+            Some(s) => match s.as_str() {
                 "alpine" => format!("zeronsd-{}", self.network),
                 _ => format!("zeronsd-{}.service", self.network),
             },
@@ -296,82 +318,77 @@ impl<'a> Properties {
         format!("com.zerotier.nsd.{}.plist", self.network)
     }
 
-    fn service_path(&self, distro: Option<&str>) -> PathBuf {
-        let dir = match distro {
-            Some(s) => match s {
+    fn service_path(&self) -> PathBuf {
+        let dir = match self.distro.clone() {
+            Some(s) => match s.as_str() {
                 "alpine" => ALPINE_INIT_DIR,
                 _ => SUPERVISE_SYSTEM_DIR,
             },
             None => SUPERVISE_SYSTEM_DIR,
         };
-        PathBuf::from(dir).join(self.service_name(distro))
+        PathBuf::from(dir).join(self.service_name())
     }
 
     pub fn install_supervisor(&mut self) -> Result<(), anyhow::Error> {
         self.validate()?;
 
         if cfg!(target_os = "linux") {
-            if let Ok(release) = std::fs::read_to_string(OS_RELEASE_FILE) {
-                let id_regex = Regex::new(r#"\nID=(.+)\n"#)?;
-                if let Some(caps) = id_regex.captures(&release) {
-                    if let Some(distro) = caps.get(1) {
-                        let distro = distro.as_str();
-
-                        let executable = match distro {
-                            "alpine" => true,
-                            _ => false,
-                        };
-
-                        let template = self.supervise_template(Some(distro))?;
-                        let service_path = self.service_path(Some(distro));
-
-                        match std::fs::write(service_path.clone(), template) {
-                            Ok(_) => {}
-                            Err(e) => {
-                                return Err(anyhow!(
-                                    "Could not write the template {}; are you root? ({})",
-                                    service_path
-                                        .to_str()
-                                        .expect("Could not coerce service path to string"),
-                                    e,
-                                ))
-                            }
-                        };
-
-                        if executable {
-                            let mut perms = std::fs::metadata(service_path.clone())?.permissions();
-                            perms.set_mode(0755);
-                            std::fs::set_permissions(service_path.clone(), perms)?;
-                        }
-
-                        let systemd_help = format!("Don't forget to `systemctl daemon-reload`, `systemctl enable zeronsd-{}` and `systemctl start zeronsd-{}`.", self.network, self.network);
-                        let alpine_help = format!(
-                            "Don't to `rc-update add zeronsd-{}` and `rc-service zeronsd-{} start`",
-                            self.network, self.network
-                        );
-
-                        let help = match distro {
-                            "alpine" => alpine_help,
-                            _ => systemd_help,
-                        };
-
-                        info!(
-                            "Service definition written to {}.\n{}",
-                            service_path
-                                .to_str()
-                                .expect("Could not coerce service path to string"),
-                            help,
-                        );
-                    } else {
-                        return Err(anyhow!("Could not determine Linux distribution; you'll need to configure supervision manually. Sorry!"));
-                    }
-                } else {
-                    return Err(anyhow!("Could not determine Linux distribution; you'll need to configure supervision manually. Sorry!"));
+            let executable = if let Some(distro) = self.distro.clone() {
+                match distro.as_str() {
+                    "alpine" => true,
+                    _ => false,
                 }
+            } else {
+                false
+            };
+
+            let template = self.supervise_template()?;
+            let service_path = self.service_path();
+
+            match std::fs::write(service_path.clone(), template) {
+                Ok(_) => {}
+                Err(e) => {
+                    return Err(anyhow!(
+                        "Could not write the template {}; are you root? ({})",
+                        service_path
+                            .to_str()
+                            .expect("Could not coerce service path to string"),
+                        e,
+                    ))
+                }
+            };
+
+            if executable {
+                let mut perms = std::fs::metadata(service_path.clone())?.permissions();
+                perms.set_mode(0755);
+                std::fs::set_permissions(service_path.clone(), perms)?;
             }
+
+            let systemd_help = format!("Don't forget to `systemctl daemon-reload`, `systemctl enable zeronsd-{}` and `systemctl start zeronsd-{}`.", self.network, self.network);
+            let alpine_help = format!(
+                "Don't to `rc-update add zeronsd-{}` and `rc-service zeronsd-{} start`",
+                self.network, self.network
+            );
+
+            let help = if let Some(distro) = self.distro.clone() {
+                match distro.as_str() {
+                    "alpine" => alpine_help,
+                    _ => systemd_help,
+                }
+            } else {
+                systemd_help
+            };
+
+            info!(
+                "Service definition written to {}.\n{}",
+                service_path
+                    .to_str()
+                    .expect("Could not coerce service path to string"),
+                help,
+            );
         } else if cfg!(target_os = "macos") {
-            let template = self.supervise_template(None)?;
-            let service_path = self.service_path(None);
+            let template = self.supervise_template()?;
+            let service_path = self.service_path();
 
             match std::fs::write(service_path.clone(), template) {
                 Ok(_) => {}
@@ -399,12 +416,12 @@ impl<'a> Properties {
 
     pub fn uninstall_supervisor(&self) -> Result<(), anyhow::Error> {
         if cfg!(target_os = "linux") {
-            match std::fs::remove_file(self.service_path(None)) {
+            match std::fs::remove_file(self.service_path()) {
                 Ok(_) => {}
                 Err(e) => {
                     return Err(anyhow!(
                         "Could not uninstall supervisor unit file ({}): {}",
-                        self.service_path(None)
+                        self.service_path()
                             .to_str()
                             .expect("Could not coerce service path to string"),
                         e,
@@ -412,12 +429,12 @@ impl<'a> Properties {
                 }
             };
         } else if cfg!(target_os = "macos") {
-            match std::fs::remove_file(self.service_path(None)) {
+            match std::fs::remove_file(self.service_path()) {
                 Ok(_) => {}
                 Err(e) => {
                     return Err(anyhow!(
                         "Could not uninstall supervisor unit file ({}): {}",
-                        self.service_path(None)
+                        self.service_path()
                             .to_str()
                             .expect("Could not coerce service path to string"),
                         e,
@@ -427,8 +444,8 @@ impl<'a> Properties {
 
             info!(
                 "Service definition removed from {}.\nDon't forget to stop it:\nsudo launchctl remove {}",
-                self.service_path(None).to_str().expect("Could not coerce service path to string"),
-                self.service_name(None).replace(".plist", "")
+                self.service_path().to_str().expect("Could not coerce service path to string"),
+                self.service_name().replace(".plist", "")
             );
         } else {
             return Err(anyhow!("Your platform is not supported for this command"));

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -258,7 +258,7 @@ impl<'a> Properties {
     fn get_service_template(&self, distro: Option<&str>) -> &str {
         match distro {
             Some(s) => match s {
-                "alpine" => ALPINE_TEMPLATE,
+                "alpine" => ALPINE_TEMPLATE.trim(),
                 _ => SYSTEMD_TEMPLATE,
             },
             None => SYSTEMD_TEMPLATE,

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -366,7 +366,7 @@ impl<'a> Properties {
 
             let systemd_help = format!("Don't forget to `systemctl daemon-reload`, `systemctl enable zeronsd-{}` and `systemctl start zeronsd-{}`.", self.network, self.network);
             let alpine_help = format!(
-                "Don't to `rc-update add zeronsd-{}` and `rc-service zeronsd-{} start`",
+                "Don't forget to `rc-update add zeronsd-{}` and `rc-service zeronsd-{} start`",
                 self.network, self.network
             );
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -162,17 +162,17 @@ fn test_supervise_systemd_green() {
             assert!(path.is_ok(), "{}", name);
             let expected = std::fs::read_to_string(path.unwrap());
             assert!(expected.is_ok(), "{}", name);
-            let testing = props.supervise_template();
+            let testing = props.supervise_template(None);
             assert!(testing.is_ok(), "{}", name);
 
             assert_eq!(testing.unwrap(), expected.unwrap(), "{}", name);
         } else {
             assert!(props.validate().is_ok(), "{}", name);
 
-            let template = props.supervise_template();
+            let template = props.supervise_template(None);
             assert!(template.is_ok(), "{}", name);
             assert!(
-                std::fs::write(path, props.supervise_template().unwrap()).is_ok(),
+                std::fs::write(path, props.supervise_template(None).unwrap()).is_ok(),
                 "{}",
                 name
             );


### PR DESCRIPTION
cc @altano -- mind testing this patch for me before I merge it?

This adds alpine support for `zeronsd supervise`, allowing you to trivially add support for the supervision of one or more zeronsd's on a single alpine host.

It also adds improved builder experience for the alpine docker image.

closes #123 