### PR TITLE
Make zeronsd into a library, support for configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .token
 test-token.txt
+/test.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1642,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "zeronsd"
 version = "0.2.7"
 dependencies = [
@@ -1646,8 +1667,10 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tinytemplate",
  "tokio",
+ "toml",
  "trust-dns-resolver",
  "trust-dns-server",
  "zerotier-central-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ zerotier-central-api = { version = "= 1.0.3" }
 zerotier-one-api = { version = "= 1.0.5" }
 serde = ">= 0"
 serde_json = ">= 0"
+serde_yaml = ">= 0"
+toml = ">=0"
 tinytemplate = ">= 0"
 rand = ">= 0"
 num_cpus = ">=0"

--- a/src/bin/zeronsd.rs
+++ b/src/bin/zeronsd.rs
@@ -1,4 +1,4 @@
-use zeronsd::init::init;
+use zeronsd::cli::init;
 
 fn main() -> Result<(), anyhow::Error> {
     init()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,7 @@
-use crate::{init::Launcher, supervise::Properties};
+use crate::{
+    init::{ConfigFormat, Launcher},
+    supervise::Properties,
+};
 use log::error;
 use std::path::PathBuf;
 
@@ -22,7 +25,7 @@ pub enum Command {
     Start(StartArgs),
 
     /// Configure supervision of the nameserver for a single network
-    Supervise(SuperviseArgs),
+    Supervise(StartArgs),
 
     /// Remove supervision of the nameserver for a network
     Unsupervise(UnsuperviseArgs),
@@ -48,49 +51,45 @@ pub struct StartArgs {
 
     /// Wildcard all names in Central to point at the respective member's IP address(es)
     #[clap(short, long)]
-    pub wildcard: bool,
+    pub wildcard: Option<bool>,
 
     /// Network ID to query
     pub network_id: String,
+
+    /// Configuration file containing these arguments (overrides most CLI options)
+    #[clap(short = 'c', long = "config", value_name = "PATH")]
+    pub config: Option<PathBuf>,
+
+    /// Configuration file format [yaml, json, toml]
+    #[clap(long = "config-type", default_value = "yaml")]
+    pub config_type: ConfigFormat,
 }
 
 impl Into<Launcher> for StartArgs {
     fn into(self) -> Launcher {
-        Launcher {
-            domain: self.domain,
-            hosts: self.hosts,
-            secret: self.secret,
-            token: self.token,
-            wildcard: self.wildcard,
-            network_id: self.network_id,
+        if let Some(config) = self.config {
+            let res = Launcher::new_from_config(config.to_str().unwrap(), self.config_type);
+            match res {
+                Ok(mut res) => {
+                    res.network_id = self.network_id.clone();
+                    res
+                }
+                Err(e) => {
+                    log::error!("{}", e);
+                    std::process::exit(1);
+                }
+            }
+        } else {
+            Launcher {
+                domain: self.domain,
+                hosts: self.hosts,
+                secret: self.secret,
+                token: self.token,
+                wildcard: self.wildcard,
+                network_id: self.network_id,
+            }
         }
     }
-}
-
-#[derive(Args)]
-pub struct SuperviseArgs {
-    /// TLD to use for hostnames
-    #[clap(short, long)]
-    pub domain: Option<String>,
-
-    /// An additional list of hosts in /etc/hosts format
-    #[clap(short = 'f', long = "file", value_name = "PATH")]
-    pub hosts: Option<PathBuf>,
-
-    /// Path to authtoken.secret (usually detected)
-    #[clap(short, long, value_name = "PATH")]
-    pub secret: Option<PathBuf>,
-
-    /// Path to a file containing the ZeroTier Central token; this file must not be moved
-    #[clap(short, long, value_name = "PATH")]
-    pub token: Option<PathBuf>,
-
-    /// Wildcard all names in Central to point at the respective member's IP address(es)
-    #[clap(short, long)]
-    pub wildcard: bool,
-
-    /// Network ID to query
-    pub network_id: String,
 }
 
 #[derive(Args)]
@@ -126,6 +125,6 @@ fn unsupervise(args: UnsuperviseArgs) -> Result<(), anyhow::Error> {
     Properties::from(args).uninstall_supervisor()
 }
 
-fn supervise(args: SuperviseArgs) -> Result<(), anyhow::Error> {
+fn supervise(args: StartArgs) -> Result<(), anyhow::Error> {
     Properties::from(args).install_supervisor()
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,138 +1,143 @@
 use std::{
-    collections::HashMap, net::SocketAddr, str::FromStr, sync::Arc, thread::sleep, time::Duration,
+    collections::HashMap, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc, thread::sleep,
+    time::Duration,
 };
 
 use anyhow::anyhow;
-use clap::Parser;
 use ipnetwork::IpNetwork;
-use log::{error, info, warn};
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
-use crate::{addresses::*, authority::*, cli::*, server::*, supervise::*, utils::*};
+use crate::{addresses::*, authority::*, server::*, utils::*};
 
-fn unsupervise(args: UnsuperviseArgs) -> Result<(), anyhow::Error> {
-    Properties::from(args).uninstall_supervisor()
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Launcher {
+    pub(crate) domain: Option<String>,
+    pub(crate) hosts: Option<PathBuf>,
+    pub(crate) secret: Option<PathBuf>,
+    pub(crate) token: Option<PathBuf>,
+    pub(crate) wildcard: bool,
+    pub(crate) network_id: String,
 }
 
-fn supervise(args: SuperviseArgs) -> Result<(), anyhow::Error> {
-    Properties::from(args).install_supervisor()
+#[derive(Debug, Clone)]
+pub enum ConfigFormat {
+    JSON,
+    YAML,
+    TOML,
 }
 
-fn start(args: StartArgs) -> Result<(), anyhow::Error> {
-    let domain_name = domain_or_default(args.domain.as_deref())?;
-    let authtoken = authtoken_path(args.secret.as_deref());
-    let runtime = &mut init_runtime();
-    let token = central_config(central_token(args.token.as_deref())?);
+impl Launcher {
+    pub fn new_from_config(filename: &str, format: ConfigFormat) -> Result<Self, anyhow::Error> {
+        let res = std::fs::read_to_string(filename)?;
+        Ok(match format {
+            ConfigFormat::JSON => serde_json::from_str(&res)?,
+            ConfigFormat::YAML => serde_yaml::from_str(&res)?,
+            ConfigFormat::TOML => toml::from_str(&res)?,
+        })
+    }
 
-    info!("Welcome to ZeroNS!");
-    let ips = runtime.block_on(get_listen_ips(&authtoken, &args.network_id))?;
+    pub fn start(&self) -> Result<(), anyhow::Error> {
+        let domain_name = domain_or_default(self.domain.as_deref())?;
+        let authtoken = authtoken_path(self.secret.as_deref());
+        let runtime = &mut init_runtime();
+        let token = central_config(central_token(self.token.as_deref())?);
 
-    // more or less the setup for the "main loop"
-    if ips.len() > 0 {
-        update_central_dns(
-            runtime,
-            domain_name.clone(),
-            ips.iter()
-                .map(|i| parse_ip_from_cidr(i.clone()).to_string())
-                .collect(),
-            token.clone(),
-            args.network_id.clone(),
-        )?;
+        info!("Welcome to ZeroNS!");
+        let ips = runtime.block_on(get_listen_ips(&authtoken, &self.network_id))?;
 
-        let mut listen_ips = Vec::new();
-        let mut ipmap = HashMap::new();
-        let mut authority_map = HashMap::new();
-        let authority = init_trust_dns_authority(domain_name.clone());
+        // more or less the setup for the "main loop"
+        if ips.len() > 0 {
+            update_central_dns(
+                runtime,
+                domain_name.clone(),
+                ips.iter()
+                    .map(|i| parse_ip_from_cidr(i.clone()).to_string())
+                    .collect(),
+                token.clone(),
+                self.network_id.clone(),
+            )?;
 
-        for cidr in ips.clone() {
-            let listen_ip = parse_ip_from_cidr(cidr.clone());
-            listen_ips.push(listen_ip.clone());
-            let cidr = IpNetwork::from_str(&cidr.clone())?;
-            if !ipmap.contains_key(&listen_ip) {
-                ipmap.insert(listen_ip, cidr.network());
-            }
+            let mut listen_ips = Vec::new();
+            let mut ipmap = HashMap::new();
+            let mut authority_map = HashMap::new();
+            let authority = init_trust_dns_authority(domain_name.clone());
 
-            if !authority_map.contains_key(&cidr) {
-                let ptr_authority = new_ptr_authority(cidr)?;
-                authority_map.insert(cidr, ptr_authority);
-            }
-        }
+            for cidr in ips.clone() {
+                let listen_ip = parse_ip_from_cidr(cidr.clone());
+                listen_ips.push(listen_ip.clone());
+                let cidr = IpNetwork::from_str(&cidr.clone())?;
+                if !ipmap.contains_key(&listen_ip) {
+                    ipmap.insert(listen_ip, cidr.network());
+                }
 
-        let network = runtime.block_on(
-            zerotier_central_api::apis::network_api::get_network_by_id(&token, &args.network_id),
-        )?;
-
-        let v6assign = network.config.clone().unwrap().v6_assign_mode;
-        if v6assign.is_some() {
-            let v6assign = v6assign.unwrap().clone();
-
-            if v6assign.var_6plane.unwrap_or(false) {
-                warn!("6PLANE PTR records are not yet supported");
-            }
-
-            if v6assign.rfc4193.unwrap_or(false) {
-                let cidr = network.clone().rfc4193().unwrap();
                 if !authority_map.contains_key(&cidr) {
                     let ptr_authority = new_ptr_authority(cidr)?;
                     authority_map.insert(cidr, ptr_authority);
                 }
             }
-        }
 
-        // ZTAuthority more or less is the mainloop. Setup continues below.
-        let mut ztauthority = ZTAuthority::new(
-            domain_name.clone(),
-            args.network_id.clone(),
-            token.clone(),
-            args.hosts.clone(),
-            authority_map.clone(),
-            Duration::new(30, 0),
-            authority.clone(),
-        );
+            let network =
+                runtime.block_on(zerotier_central_api::apis::network_api::get_network_by_id(
+                    &token,
+                    &self.network_id,
+                ))?;
 
-        if args.wildcard {
-            ztauthority.wildcard_everything();
-        }
+            let v6assign = network.config.clone().unwrap().v6_assign_mode;
+            if v6assign.is_some() {
+                let v6assign = v6assign.unwrap().clone();
 
-        let arc_authority = Arc::new(RwLock::new(ztauthority));
+                if v6assign.var_6plane.unwrap_or(false) {
+                    warn!("6PLANE PTR records are not yet supported");
+                }
 
-        runtime.spawn(find_members(arc_authority.clone()));
-
-        for ip in listen_ips {
-            info!("Your IP for this network: {}", ip);
-
-            let server = Server::new(arc_authority.to_owned());
-            runtime.spawn(server.listen(SocketAddr::new(ip, 53), Duration::new(0, 1000)));
-        }
-
-        async fn wait() {
-            loop {
-                sleep(Duration::new(60, 0))
+                if v6assign.rfc4193.unwrap_or(false) {
+                    let cidr = network.clone().rfc4193().unwrap();
+                    if !authority_map.contains_key(&cidr) {
+                        let ptr_authority = new_ptr_authority(cidr)?;
+                        authority_map.insert(cidr, ptr_authority);
+                    }
+                }
             }
+
+            // ZTAuthority more or less is the mainloop. Setup continues below.
+            let mut ztauthority = ZTAuthority::new(
+                domain_name.clone(),
+                self.network_id.clone(),
+                token.clone(),
+                self.hosts.clone(),
+                authority_map.clone(),
+                Duration::new(30, 0),
+                authority.clone(),
+            );
+
+            if self.wildcard {
+                ztauthority.wildcard_everything();
+            }
+
+            let arc_authority = Arc::new(RwLock::new(ztauthority));
+
+            runtime.spawn(find_members(arc_authority.clone()));
+
+            for ip in listen_ips {
+                info!("Your IP for this network: {}", ip);
+
+                let server = Server::new(arc_authority.to_owned());
+                runtime.spawn(server.listen(SocketAddr::new(ip, 53), Duration::new(0, 1000)));
+            }
+
+            async fn wait() {
+                loop {
+                    sleep(Duration::new(60, 0))
+                }
+            }
+
+            return Ok(runtime.block_on(wait()));
         }
 
-        return Ok(runtime.block_on(wait()));
+        return Err(anyhow!(
+            "No listening IPs for your interface; assign one in ZeroTier Central."
+        ));
     }
-
-    return Err(anyhow!(
-        "No listening IPs for your interface; assign one in ZeroTier Central."
-    ));
-}
-
-pub fn init() -> Result<(), anyhow::Error> {
-    init_logger();
-
-    let cli = Cli::parse();
-
-    let result = match cli.command {
-        Command::Start(args) => start(args),
-        Command::Supervise(args) => supervise(args),
-        Command::Unsupervise(args) => unsupervise(args),
-    };
-
-    if result.is_err() {
-        error!("{}", result.unwrap_err())
-    }
-
-    Ok(())
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -17,7 +17,8 @@ pub struct Launcher {
     pub(crate) hosts: Option<PathBuf>,
     pub(crate) secret: Option<PathBuf>,
     pub(crate) token: Option<PathBuf>,
-    pub(crate) wildcard: bool,
+    pub(crate) wildcard: Option<bool>,
+    #[serde(skip_deserializing)]
     pub(crate) network_id: String,
 }
 
@@ -26,6 +27,21 @@ pub enum ConfigFormat {
     JSON,
     YAML,
     TOML,
+}
+
+impl FromStr for ConfigFormat {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "json" | "JSON" => Ok(ConfigFormat::JSON),
+            "yaml" | "YAML" => Ok(ConfigFormat::YAML),
+            "toml" | "TOML" => Ok(ConfigFormat::TOML),
+            _ => Err(anyhow!(
+                "invalid format: allowed values: [json, yaml, toml]"
+            )),
+        }
+    }
 }
 
 impl Launcher {
@@ -112,7 +128,7 @@ impl Launcher {
                 authority.clone(),
             );
 
-            if self.wildcard {
+            if self.wildcard.is_some() && self.wildcard.unwrap() {
                 ztauthority.wildcard_everything();
             }
 


### PR DESCRIPTION
Meaning it can be consumed by other products.

It's still not documented and access to the internals is dodgy at best. This is merely a first whack at it.

This also adds support for configuration files in TOML, YAML, and JSON formats.