### PR TITLE
Expose the DNS authority; but swallow it in CLI uses. This is for library consumers

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -104,7 +104,10 @@ pub async fn init() -> Result<(), anyhow::Error> {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Command::Start(args) => start(args).await,
+        Command::Start(args) => {
+            start(args).await?;
+            Ok(())
+        }
         Command::Supervise(args) => supervise(args),
         Command::Unsupervise(args) => unsupervise(args),
     };
@@ -118,7 +121,8 @@ pub async fn init() -> Result<(), anyhow::Error> {
 
 async fn start(args: StartArgs) -> Result<(), anyhow::Error> {
     let launcher: Launcher = args.into();
-    launcher.start().await
+    launcher.start().await?;
+    Ok(())
 }
 
 fn unsupervise(args: UnsuperviseArgs) -> Result<(), anyhow::Error> {

--- a/src/init.rs
+++ b/src/init.rs
@@ -43,6 +43,8 @@ impl FromStr for ConfigFormat {
     }
 }
 
+type ArcAuthority = Arc<RwLock<ZTAuthority>>;
+
 impl Launcher {
     pub fn new_from_config(filename: &str, format: ConfigFormat) -> Result<Self, anyhow::Error> {
         let res = std::fs::read_to_string(filename)?;
@@ -53,7 +55,7 @@ impl Launcher {
         })
     }
 
-    pub async fn start(&self) -> Result<(), anyhow::Error> {
+    pub async fn start(&self) -> Result<ArcAuthority, anyhow::Error> {
         let domain_name = domain_or_default(self.domain.as_deref())?;
         let authtoken = authtoken_path(self.secret.as_deref());
         let token = central_config(central_token(self.token.as_deref())?);
@@ -141,7 +143,7 @@ impl Launcher {
                 tokio::spawn(server.listen(SocketAddr::new(ip, 53), Duration::new(0, 1000)));
             }
 
-            return Ok(());
+            return Ok(arc_authority);
         }
 
         return Err(anyhow!(


### PR DESCRIPTION
The type "ArcAuthority" was created for this purpose.

Signed-off-by: Erik Hollensbe <git@hollensbe.org>