### PR TITLE
BREAKING CHANGE: use home.arpa. (the standard TLD for home domains) as the default TLD over domain.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,7 +12,7 @@ use anyhow::anyhow;
 // collections of test hosts files
 pub const TEST_HOSTS_DIR: &str = "testdata/hosts-files";
 // default domain parameter. FIXME change to home.arpa.
-pub const DOMAIN_NAME: &str = "domain.";
+pub const DOMAIN_NAME: &str = "home.arpa.";
 // zeronsd version calculated from Cargo.toml
 pub const VERSION_STRING: &str = env!("CARGO_PKG_VERSION");
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -45,7 +45,7 @@ mod sixplane {
 
         service.change_name("islay").await;
 
-        let named_record = "islay.domain.".to_string();
+        let named_record = "islay.home.arpa.".to_string();
 
         for record in vec![member_record, named_record.clone()] {
             info!("Looking up {}", record);
@@ -79,7 +79,7 @@ mod sixplane {
             Some(
                 Path::new(&format!("{}/basic-ipv6", zeronsd::utils::TEST_HOSTS_DIR)).to_path_buf(),
             ),
-            "domain.".into_name().unwrap(),
+            "home.arpa.".into_name().unwrap(),
         )
         .unwrap();
 
@@ -110,7 +110,7 @@ mod sixplane {
         .await;
 
         let member_record = service.member_record();
-        let named_record = Name::from_str("islay.domain.").unwrap();
+        let named_record = Name::from_str("islay.home.arpa.").unwrap();
 
         service.change_name("islay").await;
 
@@ -251,7 +251,7 @@ mod rfc4193 {
 
         service.change_name("islay").await;
 
-        let named_record = "islay.domain.".to_string();
+        let named_record = "islay.home.arpa.".to_string();
 
         for record in vec![member_record, named_record.clone()] {
             info!("Looking up {}", record);
@@ -303,7 +303,7 @@ mod rfc4193 {
             Some(
                 Path::new(&format!("{}/basic-ipv6", zeronsd::utils::TEST_HOSTS_DIR)).to_path_buf(),
             ),
-            "domain.".into_name().unwrap(),
+            "home.arpa.".into_name().unwrap(),
         )
         .unwrap();
 
@@ -334,7 +334,7 @@ mod rfc4193 {
         .await;
 
         let member_record = service.member_record();
-        let named_record = Name::from_str("islay.domain.").unwrap();
+        let named_record = Name::from_str("islay.home.arpa.").unwrap();
 
         service.change_name("islay").await;
 
@@ -393,7 +393,7 @@ mod ipv4 {
         .await;
 
         let member_record = service.member_record();
-        let named_record = Name::from_str("islay.domain.").unwrap();
+        let named_record = Name::from_str("islay.home.arpa.").unwrap();
 
         service.change_name("islay").await;
 
@@ -530,7 +530,7 @@ mod ipv4 {
 
         service.change_name("islay").await;
 
-        let named_record = "islay.domain.".to_string();
+        let named_record = "islay.home.arpa.".to_string();
 
         for record in vec![member_record, named_record.clone()] {
             info!("Looking up {}", record);
@@ -602,7 +602,7 @@ mod all {
 
         let mut hosts_map = parse_hosts(
             Some(Path::new(&format!("{}/basic", TEST_HOSTS_DIR)).to_path_buf()),
-            "domain.".into_name().unwrap(),
+            "home.arpa.".into_name().unwrap(),
         )
         .unwrap();
 
@@ -639,7 +639,7 @@ mod all {
 
         assert_eq!(
             service
-                .lookup_a("islay.domain.".to_string())
+                .lookup_a("islay.home.arpa.".to_string())
                 .await
                 .first()
                 .unwrap(),
@@ -648,7 +648,7 @@ mod all {
 
         assert_eq!(
             service
-                .lookup_aaaa("islay.domain.".to_string())
+                .lookup_aaaa("islay.home.arpa.".to_string())
                 .await
                 .first()
                 .unwrap(),
@@ -660,7 +660,7 @@ mod all {
 
         assert_eq!(
             service
-                .lookup_a("islay.domain.".to_string())
+                .lookup_a("islay.home.arpa.".to_string())
                 .await
                 .first()
                 .unwrap(),
@@ -669,7 +669,7 @@ mod all {
 
         assert_eq!(
             service
-                .lookup_aaaa("islay.domain.".to_string())
+                .lookup_aaaa("islay.home.arpa.".to_string())
                 .await
                 .first()
                 .unwrap(),

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -654,7 +654,7 @@ impl Service {
     }
 
     pub fn member_record(&self) -> String {
-        format!("zt-{}.domain.", self.network().identity().clone())
+        format!("zt-{}.home.arpa.", self.network().identity().clone())
     }
 
     pub async fn change_name(&self, name: &'static str) {


### PR DESCRIPTION
This breaks zeronsd's default functionality and will move us to 0.3

closes #101

Signed-off-by: Erik Hollensbe <git@hollensbe.org>