### PR TITLE
Fix wildcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,9 @@ pub enum Command {
 
 #[derive(Args)]
 pub struct StartArgs {
+    /// Network ID to query
+    pub network_id: String,
+
     /// TLD to use for hostnames
     #[clap(short, long)]
     pub domain: Option<String>,
@@ -51,10 +54,7 @@ pub struct StartArgs {
 
     /// Wildcard all names in Central to point at the respective member's IP address(es)
     #[clap(short, long)]
-    pub wildcard: Option<bool>,
-
-    /// Network ID to query
-    pub network_id: String,
+    pub wildcard: bool,
 
     /// Configuration file containing these arguments (overrides most CLI options)
     #[clap(short = 'c', long = "config", value_name = "PATH")]

--- a/src/init.rs
+++ b/src/init.rs
@@ -16,7 +16,7 @@ pub struct Launcher {
     pub(crate) hosts: Option<PathBuf>,
     pub(crate) secret: Option<PathBuf>,
     pub(crate) token: Option<PathBuf>,
-    pub(crate) wildcard: Option<bool>,
+    pub(crate) wildcard: bool,
     #[serde(skip_deserializing)]
     pub(crate) network_id: String,
 }
@@ -128,7 +128,7 @@ impl Launcher {
                 authority.clone(),
             );
 
-            if self.wildcard.is_some() && self.wildcard.unwrap() {
+            if self.wildcard {
                 ztauthority.wildcard_everything();
             }
 

--- a/src/supervise.rs
+++ b/src/supervise.rs
@@ -130,15 +130,13 @@ impl From<StartArgs> for Properties {
     fn from(args: StartArgs) -> Self {
         let args: crate::init::Launcher = args.into();
 
-        let wildcard = args.wildcard.is_some() && args.wildcard.unwrap();
-
         Self::new(
             args.domain.as_deref(),
             &args.network_id,
             args.hosts.as_deref(),
             args.secret.as_deref(),
             args.token.as_deref(),
-            wildcard,
+            args.wildcard,
         )
         .unwrap()
     }


### PR DESCRIPTION
closes #155 

This fixes the wildcard argument requiring a field indicating "true" or "false". Caused by a misunderstand between me and the new derives we're using with clap.