### PR TITLE
support proper templating of config files in supervise

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,7 +31,7 @@ pub enum Command {
     Unsupervise(UnsuperviseArgs),
 }
 
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct StartArgs {
     /// Network ID to query
     pub network_id: String,

--- a/src/init.rs
+++ b/src/init.rs
@@ -21,7 +21,7 @@ pub struct Launcher {
     pub(crate) network_id: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum ConfigFormat {
     JSON,
     YAML,


### PR DESCRIPTION
Now `zeronsd supervise -c <config file> <network id>` works as expected.