### PR TITLE
DNS-over-TLS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .token
 test-token.txt
 /test.yaml
+/*.pem
+/*.crt
+/*.key

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1019,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -1102,6 +1149,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -1246,6 +1299,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,10 +1372,13 @@ dependencies = [
  "log",
  "radix_trie",
  "rand",
+ "ring",
+ "rustls",
  "thiserror",
  "time",
  "tokio",
  "trust-dns-proto",
+ "webpki",
 ]
 
 [[package]]
@@ -1332,6 +1399,7 @@ dependencies = [
  "lazy_static",
  "log",
  "rand",
+ "ring",
  "serde",
  "smallvec",
  "thiserror",
@@ -1354,11 +1422,32 @@ dependencies = [
  "lru-cache",
  "parking_lot 0.11.2",
  "resolv-conf",
+ "rustls",
  "serde",
  "smallvec",
  "thiserror",
  "tokio",
+ "tokio-rustls",
  "trust-dns-proto",
+ "trust-dns-rustls",
+ "webpki-roots",
+]
+
+[[package]]
+name = "trust-dns-rustls"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91135fe731d1a2f47a7032e63908e9c0c1bb02365fa5987d24fe65ecc65ee79"
+dependencies = [
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "trust-dns-proto",
+ "webpki",
 ]
 
 [[package]]
@@ -1375,14 +1464,17 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "log",
+ "rustls",
  "serde",
  "thiserror",
  "time",
  "tokio",
+ "tokio-rustls",
  "toml",
  "trust-dns-client",
  "trust-dns-proto",
  "trust-dns-resolver",
+ "trust-dns-rustls",
 ]
 
 [[package]]
@@ -1426,6 +1518,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -1541,6 +1639,25 @@ checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]
@@ -1665,11 +1782,14 @@ dependencies = [
  "num_cpus",
  "rand",
  "regex",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
  "tinytemplate",
  "tokio",
+ "tokio-rustls",
  "toml",
  "trust-dns-resolver",
  "trust-dns-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,11 @@ anyhow = ">= 0"
 clap = { version = "^3", features = ["derive"] }
 ipnetwork = ">= 0"
 trust-dns-resolver = { version = "^0.20.4", features = ["tokio-runtime"] }
-trust-dns-server = { version = "^0.20.4", features = ["trust-dns-resolver"] } 
+trust-dns-server = { version = "^0.20.4", features = ["trust-dns-resolver", "dns-over-rustls"] } 
 tokio = { version = "1", features = ["full"] }
+rustls = { version = ">= 0" }
+tokio-rustls = { version = ">= 0" }
+rustls-pemfile = { version = ">= 0" }
 zerotier-central-api = { version = "= 1.0.3" }
 zerotier-one-api = { version = "= 1.0.5" }
 serde = ">= 0"

--- a/example.conf.yaml
+++ b/example.conf.yaml
@@ -1,0 +1,30 @@
+---
+# must be set; the file containing the token used to communicate with ZeroTier
+# Central.
+token: "/home/erikh/src/github.com/zerotier/zeronsd/.token"
+# The domain to use for all subdomains. Defaults to `home.arpa.`. Trailing
+# period is not required.
+#
+# domain: "foo"
+
+# An /etc/hosts style file which contains a static list of host mappings. Does
+# not have to live on the network.
+#
+# hosts: "/etc/hosts"
+
+# The path to the authtoken.secret used to communicate with the local
+# zerotier-one instance. Only needs to be set if it is not the default, which
+# is the path below (for linux).
+#
+# secret: "/var/lib/zerotier-one/authtoken.secret"
+
+# Wildcard domains? This feature will add wildcard records for all domains
+# registered in zeronsd, so that subdomains of them can be used to point at the
+# same address; useful for vhosting.
+#
+# wildcard: false
+
+# These two parameters are the certificate and key for DNS-over-TLS.
+#
+# tls_cert: cert.pem
+# tls_key: cert.key

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,6 +63,12 @@ pub struct StartArgs {
     /// Configuration file format [yaml, json, toml]
     #[clap(long = "config-type", default_value = "yaml")]
     pub config_type: ConfigFormat,
+
+    #[clap(long = "tls-cert", value_name = "PATH")]
+    pub tls_cert: Option<PathBuf>,
+
+    #[clap(long = "tls-key", value_name = "PATH")]
+    pub tls_key: Option<PathBuf>,
 }
 
 impl Into<Launcher> for StartArgs {
@@ -86,6 +92,8 @@ impl Into<Launcher> for StartArgs {
                 secret: self.secret,
                 token: self.token,
                 wildcard: self.wildcard,
+                tls_cert: self.tls_cert,
+                tls_key: self.tls_key,
                 network_id: Some(self.network_id),
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,8 @@
 use log::warn;
-use std::{net::SocketAddr, time::Duration};
+use std::{
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
 use tokio::{
     net::{TcpListener, UdpSocket},
     time::sleep,
@@ -9,6 +12,7 @@ use trust_dns_server::server::ServerFuture;
 
 use crate::authority::{init_catalog, TokioZTAuthority};
 
+#[derive(Clone)]
 pub struct Server {
     zt: TokioZTAuthority,
 }
@@ -21,13 +25,22 @@ impl Server {
     // listener routine for TCP and UDP.
     pub async fn listen(
         self,
-        listen_addr: SocketAddr,
+        ip: IpAddr,
         tcp_timeout: Duration,
+        certs: Vec<rustls::Certificate>,
+        key: rustls::PrivateKey,
     ) -> Result<(), anyhow::Error> {
         loop {
-            let tcp = TcpListener::bind(listen_addr).await?;
-            let udp = UdpSocket::bind(listen_addr).await?;
+            let sa = SocketAddr::new(ip, 53);
+            let tcp = TcpListener::bind(sa).await?;
+            let udp = UdpSocket::bind(sa).await?;
+            let tls = TcpListener::bind(SocketAddr::new(ip, 853)).await?;
+
             let mut sf = ServerFuture::new(init_catalog(self.zt.clone()).await?);
+            match sf.register_tls_listener(tls, tcp_timeout, (certs.clone(), key.clone())) {
+                Ok(_) => {}
+                Err(e) => log::error!("Cannot start DoT listener: {}", e),
+            }
 
             sf.register_socket(udp);
             sf.register_listener(tcp, tcp_timeout);


### PR DESCRIPTION
Also adds an example configuration file. Note, that until zerotier-systemd-manager tickles the right bits this won't matter much on Linux, at least. It'll still use the old UDP/TCP setup unless it's configured manually.