### PR TITLE
Use openssl with the vendored feature (this helps build on other architectures)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.18.0+1.1.1n"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +709,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1780,6 +1790,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num_cpus",
+ "openssl",
  "rand",
  "regex",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ num_cpus = ">=0"
 log = ">=0"
 env_logger = ">=0"
 hex = ">=0"
+openssl = { version = ">= 0", features = [ "vendored" ] }
 
 [dev-dependencies]
 async-trait = ">=0"


### PR DESCRIPTION
closes #162. Thanks @daoudeddy!

Signed-off-by: Erik Hollensbe <git@hollensbe.org>