### PR TITLE
Upgrade to trust-dns v0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,8 +1262,6 @@ dependencies = [
 [[package]]
 name = "trust-dns-client"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3be5f2ead860f0d3aabc01433bc6fff0fe5e86bfbe2dd16e32b9c79959310ad"
 dependencies = [
  "cfg-if",
  "data-encoding",
@@ -1283,8 +1281,6 @@ dependencies = [
 [[package]]
 name = "trust-dns-proto"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2861b3ed517888174d13909e675c4e94b3291867512068be59d76533e4d1270c"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1311,8 +1307,6 @@ dependencies = [
 [[package]]
 name = "trust-dns-resolver"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e737a252a617bd4774649e245dbf705e207275db0893b9fa824d49f074fc1c"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1333,8 +1327,6 @@ dependencies = [
 [[package]]
 name = "trust-dns-server"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4058838790565ba870cb800008c7b3b8a3f154afaece824ad9a91a80a4b81dfb"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,27 +150,14 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-as-inner"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570d109b813e904becc80d8d5da38376818a143348413f7149f1340fe04754d4"
+checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -408,7 +395,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.4",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -460,14 +447,14 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
+checksum = "723519edce41262b05d4143ceb95050e4c614f483e78e9fd9e39a8275a84ad98"
 dependencies = [
- "socket2 0.3.19",
+ "socket2",
  "widestring",
  "winapi",
- "winreg 0.6.2",
+ "winreg 0.7.0",
 ]
 
 [[package]]
@@ -508,9 +495,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "linked-hash-map"
@@ -717,37 +704,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1086,17 +1048,6 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
@@ -1218,10 +1169,10 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.4",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
@@ -1310,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-client"
-version = "0.20.4"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4ef9b9bde0559b78a4abb00339143750085f05e5a453efb7b8bef1061f09dc"
+checksum = "a3be5f2ead860f0d3aabc01433bc6fff0fe5e86bfbe2dd16e32b9c79959310ad"
 dependencies = [
  "cfg-if",
  "data-encoding",
@@ -1330,24 +1281,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-openssl"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ded13e330362b832b1d7d7498f3fc73bde2987fd083ff60d29a9c70247edc6a"
-dependencies = [
- "futures-channel",
- "futures-util",
- "openssl",
- "tokio",
- "tokio-openssl",
- "trust-dns-proto",
-]
-
-[[package]]
 name = "trust-dns-proto"
-version = "0.20.4"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca94d4e9feb6a181c690c4040d7a24ef34018d8313ac5044a61d21222ae24e31"
+checksum = "2861b3ed517888174d13909e675c4e94b3291867512068be59d76533e4d1270c"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1367,14 +1304,15 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tokio",
+ "tokio-openssl",
  "url",
 ]
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.20.4"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecae383baad9995efaa34ce8e57d12c3f305e545887472a492b838f4b5cfb77a"
+checksum = "d9e737a252a617bd4774649e245dbf705e207275db0893b9fa824d49f074fc1c"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1382,28 +1320,27 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
- "parking_lot 0.11.2",
+ "parking_lot",
  "resolv-conf",
  "serde",
  "smallvec",
  "thiserror",
  "tokio",
  "tokio-openssl",
- "trust-dns-openssl",
  "trust-dns-proto",
 ]
 
 [[package]]
 name = "trust-dns-server"
-version = "0.20.4"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88890d985c620b6027a0b85b71b772d35c6fcc3c8e6bd4e326af7dae0ea75d45"
+checksum = "4058838790565ba870cb800008c7b3b8a3f154afaece824ad9a91a80a4b81dfb"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "enum-as-inner",
- "env_logger 0.8.4",
+ "env_logger",
  "futures-executor",
  "futures-util",
  "log",
@@ -1415,7 +1352,6 @@ dependencies = [
  "tokio-openssl",
  "toml",
  "trust-dns-client",
- "trust-dns-openssl",
  "trust-dns-proto",
  "trust-dns-resolver",
 ]
@@ -1466,6 +1402,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -1580,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
+checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "winapi"
@@ -1660,9 +1597,9 @@ checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
@@ -1692,7 +1629,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "env_logger 0.9.0",
+ "env_logger",
  "hex",
  "ipnetwork",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ dependencies = [
 [[package]]
 name = "trust-dns-client"
 version = "0.21.1"
+source = "git+https://github.com/erikh/trust-dns?branch=rwlock-inmemorystore#7498308e81cfea4646c6e2ecb8f8d03a484a1683"
 dependencies = [
  "cfg-if",
  "data-encoding",
@@ -1281,6 +1282,7 @@ dependencies = [
 [[package]]
 name = "trust-dns-proto"
 version = "0.21.1"
+source = "git+https://github.com/erikh/trust-dns?branch=rwlock-inmemorystore#7498308e81cfea4646c6e2ecb8f8d03a484a1683"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1307,6 +1309,7 @@ dependencies = [
 [[package]]
 name = "trust-dns-resolver"
 version = "0.21.1"
+source = "git+https://github.com/erikh/trust-dns?branch=rwlock-inmemorystore#7498308e81cfea4646c6e2ecb8f8d03a484a1683"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1327,6 +1330,7 @@ dependencies = [
 [[package]]
 name = "trust-dns-server"
 version = "0.21.1"
+source = "git+https://github.com/erikh/trust-dns?branch=rwlock-inmemorystore#7498308e81cfea4646c6e2ecb8f8d03a484a1683"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ regex = ">= 0"
 anyhow = ">= 0"
 clap = { version = "^3", features = ["derive"] }
 ipnetwork = ">= 0"
-trust-dns-resolver = { version = "^0.21.0", features = ["tokio-runtime", "dns-over-openssl"] }
-trust-dns-server = { version = "^0.21.0", features = ["trust-dns-resolver", "dns-over-openssl"] } 
+trust-dns-resolver = { version = "^0.21.0", features = ["tokio-runtime", "dns-over-openssl"], path = "../../bluejekyll/trust-dns/crates/resolver" }
+trust-dns-server = { version = "^0.21.0", features = ["trust-dns-resolver", "dns-over-openssl"], path = "../../bluejekyll/trust-dns/crates/server" } 
 tokio = { version = "1", features = ["full"] }
 zerotier-central-api = { version = "= 1.0.3" }
 zerotier-one-api = { version = "= 1.0.5" }
@@ -34,9 +34,9 @@ log = ">=0"
 env_logger = ">=0"
 hex = ">=0"
 openssl = { version = ">= 0", features = [ "vendored" ] }
+async-trait = ">=0"
 
 [dev-dependencies]
-async-trait = ">=0"
 lazy_static = ">=0"
 
 [package.metadata.deb]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ regex = ">= 0"
 anyhow = ">= 0"
 clap = { version = "^3", features = ["derive"] }
 ipnetwork = ">= 0"
-trust-dns-resolver = { version = "^0.20.4", features = ["tokio-runtime"] }
-trust-dns-server = { version = "^0.20.4", features = ["trust-dns-resolver", "dns-over-openssl"] } 
+trust-dns-resolver = { version = "^0.21.0", features = ["tokio-runtime", "dns-over-openssl"] }
+trust-dns-server = { version = "^0.21.0", features = ["trust-dns-resolver", "dns-over-openssl"] } 
 tokio = { version = "1", features = ["full"] }
 zerotier-central-api = { version = "= 1.0.3" }
 zerotier-one-api = { version = "= 1.0.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ regex = ">= 0"
 anyhow = ">= 0"
 clap = { version = "^3", features = ["derive"] }
 ipnetwork = ">= 0"
-trust-dns-resolver = { version = "^0.21.0", features = ["tokio-runtime", "dns-over-openssl"], path = "../../bluejekyll/trust-dns/crates/resolver" }
-trust-dns-server = { version = "^0.21.0", features = ["trust-dns-resolver", "dns-over-openssl"], path = "../../bluejekyll/trust-dns/crates/server" } 
+trust-dns-resolver = { version = "^0.21.0", features = ["tokio-runtime", "dns-over-openssl"], git = "https://github.com/erikh/trust-dns", branch = "rwlock-inmemorystore" }
+trust-dns-server = { version = "^0.21.0", features = ["trust-dns-resolver", "dns-over-openssl"], git = "https://github.com/erikh/trust-dns", branch = "rwlock-inmemorystore" }
 tokio = { version = "1", features = ["full"] }
 zerotier-central-api = { version = "= 1.0.3" }
 zerotier-one-api = { version = "= 1.0.5" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod hosts;
 pub mod server;
 pub mod supervise;
+pub mod traits;
 pub mod utils;
 
 pub mod init;

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,26 +3,24 @@ use std::{
     net::{IpAddr, SocketAddr},
     time::Duration,
 };
-use tokio::net::{TcpListener, UdpSocket};
 
 use openssl::{
     pkey::{PKey, Private},
     stack::Stack,
     x509::X509,
 };
+use tokio::net::{TcpListener, UdpSocket};
 
 use trust_dns_server::server::ServerFuture;
 
-use crate::authority::{init_catalog, TokioZTAuthority};
+use crate::authority::{init_catalog, ZTAuthority};
 
 #[derive(Clone)]
-pub struct Server {
-    zt: TokioZTAuthority,
-}
+pub struct Server(ZTAuthority);
 
 impl Server {
-    pub fn new(zt: TokioZTAuthority) -> Self {
-        return Self { zt };
+    pub fn new(zt: ZTAuthority) -> Self {
+        return Self(zt);
     }
 
     // listener routine for TCP and UDP.
@@ -37,7 +35,7 @@ impl Server {
         let tcp = TcpListener::bind(sa).await?;
         let udp = UdpSocket::bind(sa).await?;
 
-        let mut sf = ServerFuture::new(init_catalog(self.zt.clone()).await?);
+        let mut sf = ServerFuture::new(init_catalog(self.0).await?);
 
         if certs.is_some() && key.is_some() {
             info!("Configuring DoT Listener");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -310,7 +310,10 @@ fn test_parse_hosts() {
                     .unwrap()
                     .first()
                     .unwrap(),
-                &Name::from_str("localhost").unwrap().append_domain(domain),
+                &Name::from_str("localhost")
+                    .unwrap()
+                    .append_domain(domain)
+                    .unwrap(),
                 "{}",
                 path.path().display(),
             );
@@ -321,14 +324,17 @@ fn test_parse_hosts() {
                     .unwrap()
                     .first()
                     .unwrap(),
-                &Name::from_str("localhost").unwrap().append_domain(domain),
+                &Name::from_str("localhost")
+                    .unwrap()
+                    .append_domain(domain)
+                    .unwrap(),
                 "{}",
                 path.path().display(),
             );
 
             let mut accounted = vec!["islay.localdomain", "islay"]
                 .into_iter()
-                .map(|s| Name::from_str(s).unwrap().append_domain(domain));
+                .map(|s| Name::from_str(s).unwrap().append_domain(domain).unwrap());
 
             for name in table
                 .remove(&IpAddr::from_str("127.0.1.1").unwrap())
@@ -359,10 +365,16 @@ fn test_parse_hosts_duplicate() {
     assert!(result.is_some());
     let result = result.unwrap();
 
-    assert!(result.contains(&Name::from_str("hostname1").unwrap().append_domain(&domain)));
+    assert!(result.contains(
+        &Name::from_str("hostname1")
+            .unwrap()
+            .append_domain(&domain)
+            .unwrap()
+    ));
     assert!(result.contains(
         &Name::from_str("hostname2.corp")
             .unwrap()
             .append_domain(&domain)
+            .unwrap()
     ));
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,36 @@
+use ipnetwork::IpNetwork;
+use std::str::FromStr;
+use trust_dns_resolver::{proto::error::ProtoError, IntoName, Name};
+use trust_dns_server::client::rr::LowerName;
+
+pub trait ToPointerSOA {
+    fn to_ptr_soa_name(self) -> Result<LowerName, ProtoError>;
+}
+
+impl ToPointerSOA for IpNetwork {
+    fn to_ptr_soa_name(self) -> Result<LowerName, ProtoError> {
+        // how many bits in each ptr octet
+        let octet_factor = match self {
+            IpNetwork::V4(_) => 8,
+            IpNetwork::V6(_) => 4,
+        };
+
+        Ok(self
+            .network()
+            .into_name()?
+            // round off the subnet, account for in-addr.arpa.
+            .trim_to((self.prefix() as usize / octet_factor) + 2)
+            .into())
+    }
+}
+
+pub trait ToWildcard {
+    fn to_wildcard(self) -> Name;
+}
+
+impl ToWildcard for Name {
+    fn to_wildcard(self) -> Name {
+        let name = Self::from_str("*").unwrap();
+        name.append_domain(&self).unwrap().into_wildcard()
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -211,7 +211,7 @@ impl ToHostname for &str {
     }
 
     fn to_fqdn(self, domain: Name) -> Result<Name, anyhow::Error> {
-        Ok(self.to_hostname()?.append_domain(&domain))
+        Ok(self.to_hostname()?.append_domain(&domain).unwrap())
     }
 }
 
@@ -237,6 +237,6 @@ impl ToHostname for String {
     }
 
     fn to_fqdn(self, domain: Name) -> Result<Name, anyhow::Error> {
-        Ok(self.to_hostname()?.append_domain(&domain))
+        Ok(self.to_hostname()?.append_domain(&domain).unwrap())
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -137,6 +137,7 @@ mod sixplane {
                 let lookup = Name::from_str(&host)
                     .unwrap()
                     .append_domain(&Name::from_str(&rec).unwrap())
+                    .unwrap()
                     .to_string();
                 assert_eq!(
                     service.lookup_aaaa(lookup).await.first().unwrap(),
@@ -361,6 +362,7 @@ mod rfc4193 {
                 let lookup = Name::from_str(&host)
                     .unwrap()
                     .append_domain(&Name::from_str(&rec).unwrap())
+                    .unwrap()
                     .to_string();
                 assert_eq!(
                     service.lookup_aaaa(lookup).await.first().unwrap(),
@@ -420,6 +422,7 @@ mod ipv4 {
                 let lookup = Name::from_str(&host)
                     .unwrap()
                     .append_domain(&Name::from_str(&rec).unwrap())
+                    .unwrap()
                     .to_string();
                 assert_eq!(
                     service.lookup_a(lookup).await.first().unwrap(),


### PR DESCRIPTION
This gets us fully compliant with trust-dns v0.21.1. It also rewrites the authority code which was a mess.

There are probably a few bugs still; shaking those out before I merge.