### PR TITLE
Leverage tracing-log package, update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "trust-dns-resolver",
  "trust-dns-server",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
@@ -382,9 +382,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.17"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
 ]
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -826,9 +826,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
 dependencies = [
  "bitflags",
 ]
@@ -1112,9 +1112,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1181,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
  "libc",
  "num_threads",
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "trust-dns-client"
 version = "0.21.1"
-source = "git+https://github.com/erikh/trust-dns?branch=tracing#296d07e3e34eed745ac0c5b1086ddb78564e5a59"
+source = "git+https://github.com/erikh/trust-dns?branch=tracing#03e763f28010a0ac3b7f2f745f77c4fa8b403cb8"
 dependencies = [
  "cfg-if",
  "data-encoding",
@@ -1389,14 +1389,13 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "trust-dns-proto",
 ]
 
 [[package]]
 name = "trust-dns-proto"
 version = "0.21.1"
-source = "git+https://github.com/erikh/trust-dns?branch=tracing#296d07e3e34eed745ac0c5b1086ddb78564e5a59"
+source = "git+https://github.com/erikh/trust-dns?branch=tracing#03e763f28010a0ac3b7f2f745f77c4fa8b403cb8"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1417,14 +1416,13 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "tracing",
- "tracing-subscriber",
  "url",
 ]
 
 [[package]]
 name = "trust-dns-resolver"
 version = "0.21.1"
-source = "git+https://github.com/erikh/trust-dns?branch=tracing#296d07e3e34eed745ac0c5b1086ddb78564e5a59"
+source = "git+https://github.com/erikh/trust-dns?branch=tracing#03e763f28010a0ac3b7f2f745f77c4fa8b403cb8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1439,14 +1437,13 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "tracing",
- "tracing-subscriber",
  "trust-dns-proto",
 ]
 
 [[package]]
 name = "trust-dns-server"
 version = "0.21.1"
-source = "git+https://github.com/erikh/trust-dns?branch=tracing#296d07e3e34eed745ac0c5b1086ddb78564e5a59"
+source = "git+https://github.com/erikh/trust-dns?branch=tracing#03e763f28010a0ac3b7f2f745f77c4fa8b403cb8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1462,7 +1459,6 @@ dependencies = [
  "tokio-openssl",
  "toml",
  "tracing",
- "tracing-subscriber",
  "trust-dns-client",
  "trust-dns-proto",
  "trust-dns-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tinytemplate = ">= 0"
 rand = ">= 0"
 num_cpus = ">=0"
 tracing = "0.1"
+tracing-log = "0.1"
 tracing-subscriber = "0.2"
 hex = ">=0"
 openssl = { version = ">= 0", features = [ "vendored" ] }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,6 +46,8 @@ pub fn init_logger(level: Option<tracing::Level>) {
             level
         };
 
+        tracing_log::log_tracer::LogTracer::init().expect("initializing logger failed");
+
         if let Some(level) = level {
             let subscriber = tracing_subscriber::FmtSubscriber::builder()
                 // all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)


### PR DESCRIPTION
This leverages the tracing-log crate to unify log and tracing so we get all the data.