### PR TITLE
Fix use of vendored feature in openssl dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "c67e7973e74896f4bba06ca2dcfd28d54f9cb8c035e940a32b88ed48f5f5ecf2"
 dependencies = [
  "atty",
  "bitflags",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.4"
+version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -795,9 +795,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,11 @@ tracing = "0.1"
 tracing-log = "0.1"
 tracing-subscriber = "0.2"
 hex = ">=0"
-openssl = { version = ">= 0", features = [ "vendored" ] }
+openssl = ">= 0"
 async-trait = ">=0"
+
+[features]
+vendored-openssl = [ "openssl/vendored" ]
 
 [dev-dependencies]
 lazy_static = ">=0"

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -16,7 +16,7 @@ RUN apk add openssl-dev
 COPY . /zeronsd
 WORKDIR /zeronsd
 
-RUN OPENSSL_NO_VENDOR=1 cargo install --path .
+RUN cargo install --release --path .
 
 FROM alpine:latest
 

--- a/cargo-docker.sh
+++ b/cargo-docker.sh
@@ -2,9 +2,9 @@
 
 if [ "${IS_LOCAL}" != 0 ]
 then
-  cargo install --path .
+  cargo install --release --path .
 else
-  cargo install --git https://github.com/zerotier/zeronsd \
+  cargo install --release --git https://github.com/zerotier/zeronsd \
     $(if [ "${IS_TAG}" != "0" ]; then echo "--tag"; else echo "--branch"; fi) \
     "${VERSION}"
 fi


### PR DESCRIPTION
This was causing build problems in other architectures, notably Windows.
To use the vendored openssl, you can now:

```
cargo build --features vendored-openssl
```

Signed-off-by: Erik Hollensbe <git@hollensbe.org>