### PR TITLE
link to central/one service API repos directly instead of crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "zeronsd"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2125,6 +2125,7 @@ dependencies = [
  "ipnetwork",
  "lazy_static",
  "openssl",
+ "percent-encoding",
  "rand",
  "regex",
  "reqwest",
@@ -2146,8 +2147,7 @@ dependencies = [
 [[package]]
 name = "zerotier-central-api"
 version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcbbc3ebfe848d2305d8f4bec2ae68d81bcdde1d9ff2f14e7957e8608a9a0c7"
+source = "git+https://github.com/zerotier/zerotier-rust-api#ba2609cec50662f1d4023c7778d7c760a370f17d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2163,8 +2163,7 @@ dependencies = [
 [[package]]
 name = "zerotier-one-api"
 version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df22f59fd0537dc76b31474d1b2af45f0a8fafa1b7edaa0f2127c2688bfb1795"
+source = "git+https://github.com/zerotier/zerotier-rust-api#ba2609cec50662f1d4023c7778d7c760a370f17d"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeronsd"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Erik Hollensbe <linux@hollensbe.org>", "Adam Ierymenko <adam.ierymenko@zerotier.com>"]
 description = "Unicast DNS resolver for ZeroTier networks"
 homepage = "https://github.com/zerotier/zeronsd"
@@ -24,8 +24,8 @@ tokio = { version = "1", features = ["full"] }
 serde = ">=0"
 serde_json = ">=0"
 serde_yaml = ">=0"
-zerotier-central-api = "=1.2.1"
-zerotier-one-api = "=1.2.1"
+zerotier-central-api = {version = "=1.2.1", git = "https://github.com/zerotier/zerotier-rust-api"}
+zerotier-one-api = {version = "=1.2.1", git = "https://github.com/zerotier/zerotier-rust-api"}
 toml = ">=0"
 tinytemplate = ">=0"
 rand = ">=0"
@@ -37,6 +37,7 @@ openssl = ">=0"
 async-trait = ">=0"
 lazy_static = ">=0"
 reqwest = ">=0"
+percent-encoding = "^2.2"
 
 [features]
 vendored-openssl = [ "openssl/vendored" ]


### PR DESCRIPTION
Since we can't yet update the `zerotier-central-api` and `zerotier-one-api` crates directly, link directly to the git repository for them instead.