### PR TITLE
Create a command line option no-configure-network

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,7 +81,7 @@ pub struct StartArgs {
     #[clap(short = 'l', long = "log-level", value_name = "LEVEL")]
     pub log_level: Option<crate::log::LevelFilter>,
 
-    /// Don't configure the ZeroTier network's dns servers and domain.
+    /// Don't configure the ZeroTier network's dns servers and domain. Default: False
     #[clap(long = "no-configure-network")]
     pub no_configure_network: bool,
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -34,6 +34,7 @@ pub struct Launcher {
     pub local_url: String,
     #[serde(skip_deserializing)]
     pub network_id: Option<String>,
+    #[serde(default = "bool::default")]
     pub no_configure_network: bool,
 }
 


### PR DESCRIPTION
For #205
Makes it not configure the dns servers and domain
on the zerotier network in my.zerotier.com

That was easy.
Will try to add a test if I get motivated. 