### PR TITLE
upgrade trust-dns to v0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,27 +198,14 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-as-inner"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -469,12 +456,6 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1678,30 +1659,30 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-client"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d9ba1c6079f6f9b4664e482db1700bd53d2ee77b1c9752c1d7a66c0c8bda99"
+checksum = "6c408c32e6a9dbb38037cece35740f2cf23c875d8ca134d33631cec83f74d3fe"
 dependencies = [
  "cfg-if",
  "data-encoding",
  "futures-channel",
  "futures-util",
  "lazy_static",
- "log",
  "openssl",
  "radix_trie",
  "rand",
  "thiserror",
  "time 0.3.9",
  "tokio",
+ "tracing",
  "trust-dns-proto",
 ]
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c31f240f59877c3d4bb3b3ea0ec5a6a0cff07323580ff8c7a605cd7d08b255d"
+checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1713,7 +1694,6 @@ dependencies = [
  "idna",
  "ipnet",
  "lazy_static",
- "log",
  "openssl",
  "rand",
  "serde",
@@ -1722,20 +1702,20 @@ dependencies = [
  "tinyvec",
  "tokio",
  "tokio-openssl",
+ "tracing",
  "url",
 ]
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ba72c2ea84515690c9fcef4c6c660bb9df3036ed1051686de84605b74fd558"
+checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
 dependencies = [
  "cfg-if",
  "futures-util",
  "ipconfig",
  "lazy_static",
- "log",
  "lru-cache",
  "parking_lot",
  "resolv-conf",
@@ -1744,23 +1724,22 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-openssl",
+ "tracing",
  "trust-dns-proto",
 ]
 
 [[package]]
 name = "trust-dns-server"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a395a2e0fd8aac9b4613767a5b4ba4b2040de1b767fa03ace8c9d6f351d60b2d"
+checksum = "1583cf9f8a359c9f16fdf760b79cb2be3f261b98db8027f81959c7a4f6645e2c"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "enum-as-inner",
- "env_logger",
  "futures-executor",
  "futures-util",
- "log",
  "openssl",
  "serde",
  "thiserror",
@@ -1768,6 +1747,7 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "toml",
+ "tracing",
  "trust-dns-client",
  "trust-dns-proto",
  "trust-dns-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ regex = ">=0"
 anyhow = ">=0"
 clap = { version = "^3", features = ["derive"] }
 ipnetwork = ">=0"
-trust-dns-resolver = { version = "^0.21.0", features = ["tokio-runtime", "dns-over-openssl"] }
-trust-dns-server = { version = "^0.21.0", features = ["trust-dns-resolver", "dns-over-openssl"] }
+trust-dns-resolver = { version = "^0.22.0", features = ["tokio-runtime", "dns-over-openssl"] }
+trust-dns-server = { version = "^0.22.0", features = ["trust-dns-resolver", "dns-over-openssl"] }
 tokio = { version = "1", features = ["full"] }
 serde = ">=0"
 serde_json = ">=0"

--- a/src/authority.rs
+++ b/src/authority.rs
@@ -75,9 +75,7 @@ pub async fn init_catalog(zt: ZTAuthority) -> Result<Catalog, anyhow::Error> {
         Name::root(),
         trust_dns_server::authority::ZoneType::Primary,
         config,
-    )
-    .await
-    .expect("Could not initialize forwarder");
+    ).expect("Could not initialize forwarder");
 
     catalog.upsert(Name::root().into(), Box::new(Arc::new(forwarder)));
 


### PR DESCRIPTION
This upgrades trust-dns to v0.22 and will likely be my last patch to this project. I checked `make test` (which only runs `--lib`, not the integration tests) and all seemed to work fine, but a second validation pass would be a good idea.

I'm still happy to offer help with cutting releases, it's especially tricky on windows but the brew tap is also a little finicky. I won't be providing patches any further as I don't want to involve myself in a conflict of interest for any future work I'm doing.

Wish you all the best, and may you have names for all your zerotier IPs.