### PR TITLE
improve rfc4193 related integration test failures

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -142,6 +142,8 @@ impl Launcher {
                 let cidr = IpNetwork::from_str(&cidr.clone())?;
                 ipmap.entry(listen_ip).or_insert_with(|| cidr.network());
 
+                let cidr = IpNetwork::new(cidr.network(), cidr.prefix()).unwrap();
+
                 if let Entry::Vacant(e) = authority_map.entry(cidr) {
                     tracing::debug!("{}", cidr.to_ptr_soa_name()?);
                     let ptr_authority =

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -139,6 +139,10 @@ mod tests {
                 IpNetwork::from_str("1.2.3.4/32").unwrap(),
                 LowerName::from_str("4.3.2.1.in-addr.arpa").unwrap(),
             ),
+            (
+                IpNetwork::from_str("fd0c:ccb7:52f7:13c4:7c99:9312:1234:5678/88").unwrap(),
+                LowerName::from_str("3.9.9.9.c.7.4.c.3.1.7.f.2.5.7.b.c.c.c.0.d.f.ip6.arpa").unwrap(),
+            )
         ] {
             assert_eq!(item.0.to_ptr_soa_name().unwrap(), item.1);
         }

--- a/tests/service/mod.rs
+++ b/tests/service/mod.rs
@@ -187,6 +187,7 @@ impl Service {
                 ipmap.insert(listen_ip, cidr.network());
             }
 
+            let cidr = IpNetwork::new(cidr.network(), cidr.prefix()).unwrap();
             if !authority_map.contains_key(&cidr) {
                 let ptr_authority = RecordAuthority::new(
                     cidr.to_ptr_soa_name().unwrap(),


### PR DESCRIPTION
re issue #209

they would fail _sometimes_
so far so good with this change

this change inserts
fd23:3cca:ac27:8e85:c199:9300::/88

instead of
fd23:3cca:ac27:8e85:c199:93e7:50c5:1646/88
into the reverse ptr authority

actually it would insert 1 of each before

so there would be 2 SOA things, but
only 1 would have the actual ptr records on it
and then lookups would fail _sometimes_

