### PR TITLE
Update trust-dns (hickory-dns)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,7 +52,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -83,6 +77,28 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "backtrace"
@@ -113,9 +129,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -131,24 +147,39 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -167,13 +198,34 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive 4.5.55",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstyle",
+ "clap_lex 1.1.0",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -190,12 +242,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -209,10 +298,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "ctor"
@@ -221,7 +350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.79",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -238,6 +367,23 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -262,14 +408,14 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -279,14 +425,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno"
-version = "0.3.9"
+name = "fallible-iterator"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -295,25 +443,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
+name = "foldhash"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -323,6 +474,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -351,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
@@ -380,7 +537,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -420,8 +577,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -442,11 +615,39 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "h3"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfb059a4f28a66f186ed16ad912d142f490676acba59353831d7cb45a96b0d3"
+dependencies = [
+ "bytes",
+ "fastrand",
+ "futures-util",
+ "http",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "h3-quinn"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d482318ae94198fc8e3cbb0b7ba3099c865d744e6ec7c62039ca7b6b6c66fbf"
+dependencies = [
+ "bytes",
+ "futures",
+ "h3",
+ "quinn",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -457,19 +658,38 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "ahash",
- "allocator-api2",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.2",
+]
 
 [[package]]
 name = "heck"
@@ -505,6 +725,143 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-client"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c466cd63a4217d5b2b8e32f23f58312741ce96e3c84bf7438677d2baff0fc555"
+dependencies = [
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-util",
+ "hickory-proto",
+ "once_cell",
+ "radix_trie",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-dns"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13522c12e59f691677a26689f228079e410873ce3a836b33733a4a908158646e"
+dependencies = [
+ "cfg-if",
+ "clap 4.5.60",
+ "futures-util",
+ "hickory-client",
+ "hickory-proto",
+ "hickory-server",
+ "ipnet",
+ "libc",
+ "rusqlite",
+ "rustls",
+ "serde",
+ "socket2 0.5.7",
+ "time",
+ "tokio",
+ "toml 0.8.20",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2",
+ "h3",
+ "h3-quinn",
+ "http",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "pin-project-lite",
+ "quinn",
+ "rand 0.9.4",
+ "ring",
+ "rustls",
+ "rustls-platform-verifier 0.5.3",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "quinn",
+ "rand 0.9.4",
+ "resolv-conf",
+ "rustls",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-server"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53e5fe811b941c74ee46b8818228bfd2bc2688ba276a0eaeb0f2c95ea3b2585"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-util",
+ "h2",
+ "h3",
+ "h3-quinn",
+ "hickory-proto",
+ "hickory-resolver",
+ "http",
+ "ipnet",
+ "prefix-trie",
+ "rusqlite",
+ "rustls",
+ "serde",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "toml 0.8.20",
+ "tracing",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,12 +874,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -557,13 +913,14 @@ checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -593,59 +950,131 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "idna_adapter"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -660,13 +1089,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.17.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -675,7 +1105,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.7",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -686,6 +1116,9 @@ name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ipnetwork"
@@ -697,17 +1130,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "js-sys"
-version = "0.3.72"
+name = "jni"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.64",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -719,9 +1219,20 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947e6816f7825b2b45027c2c32e7085da9934defa535de4a6a46b10a4d5257fa"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "libyml"
@@ -734,16 +1245,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
+name = "litemap"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -757,18 +1262,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lru-cache"
+name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "match_cfg"
@@ -777,10 +1279,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
-name = "matches"
-version = "0.1.10"
+name = "matchers"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "memchr"
@@ -816,20 +1321,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.12"
+name = "moka"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -880,71 +1385,27 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "openapiv3"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc02deea53ffe807708244e5914f6b099ad7015a207ee24317c22112e17d9c5c"
+checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-src"
-version = "300.3.2+3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.105"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "os_str_bytes"
@@ -983,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -1006,6 +1467,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,13 +1497,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cf4c7c25f1dd66c76b451e9041a8cfce26e4ca754934fa7aed8d5a59a01d20"
+dependencies = [
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.79",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1056,18 +1542,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "progenitor"
-version = "0.8.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293df5b79211fbf0c1ebad6513ba451d267e9c15f5f19ee5d3da775e2dd27331"
+checksum = "d36315275b213c64c68dff684477ea7118a0f630832f737b550796a368f9962c"
 dependencies = [
  "progenitor-client",
  "progenitor-impl",
@@ -1076,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "progenitor-client"
-version = "0.8.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a5db54eac3cae7007a0785854bc3e89fd418cca7dfc2207b99b43979154c1b"
+checksum = "3999c302f5f2a42b7ca1cc39ad9e612c74cf2910ef6e58f869e45f3068b9659f"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1091,13 +1577,13 @@ dependencies = [
 
 [[package]]
 name = "progenitor-impl"
-version = "0.8.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85934a440963a69f9f04f48507ff6e7aa2952a5b2d8f96cc37fa3dd5c270f66"
+checksum = "de362a0477182f45accdbad4d43cd89a95a1db0a518a7c1ddf3e525e6896f0f0"
 dependencies = [
  "heck 0.5.0",
  "http",
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "openapiv3",
  "proc-macro2",
  "quote",
@@ -1105,17 +1591,17 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "syn 2.0.79",
- "thiserror",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
  "typify",
  "unicode-ident",
 ]
 
 [[package]]
 name = "progenitor-macro"
-version = "0.8.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99a5a259e2d65a4933054aa51717c70b6aba0522695731ac354a522124efc9b"
+checksum = "c98aeaaab266bf848a602c78e039e7d62c80ba36303ae4092ec65f17e7fd0eaa"
 dependencies = [
  "openapiv3",
  "proc-macro2",
@@ -1126,7 +1612,7 @@ dependencies = [
  "serde_json",
  "serde_tokenstream",
  "serde_yaml",
- "syn 2.0.79",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1136,13 +1622,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quote"
-version = "1.0.37"
+name = "quinn"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "futures-io",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radix_trie"
@@ -1161,8 +1710,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1172,7 +1731,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1181,7 +1750,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1190,31 +1768,46 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.14",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1224,19 +1817,19 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "regress"
-version = "0.10.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1541daf4e4ed43a0922b7969bdc2170178bcacc5dabf7e39bc508a9fa3953a7a"
+checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "memchr",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.8"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
@@ -1249,32 +1842,31 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
@@ -1295,10 +1887,25 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22715a5d6deef63c637207afbe68d0c72c3f8d0022d7cf9714c442d6157606b"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "time",
 ]
 
 [[package]]
@@ -1308,25 +1915,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustix"
-version = "0.38.37"
+name = "rustc-hash"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
-dependencies = [
- "bitflags 2.6.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
-]
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1334,36 +1937,107 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
+name = "rustls-native-certs"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
+ "openssl-probe",
  "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 1.0.6",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1376,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -1390,14 +2064,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.79",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1408,12 +2082,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.6.0",
- "core-foundation",
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1421,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1431,31 +2105,42 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1466,19 +2151,20 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.130"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610f75ff4a8e3cb29b85da56eabdd1bff5b06739059a4b8e2967fef32e5d9944"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1492,14 +2178,14 @@ dependencies = [
 
 [[package]]
 name = "serde_tokenstream"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64060d864397305347a78851c51588fd283767e7e7589829e8121d65512340f1"
+checksum = "d7c49585c52c01f13c5c2ebb333f14f6885d76daa768d8a037d28017ec538c69"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.79",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1520,7 +2206,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -1533,7 +2219,7 @@ version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "itoa",
  "libyml",
  "memchr",
@@ -1592,10 +2278,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1616,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1635,13 +2343,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.6.1"
+name = "synstructure"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
- "bitflags 2.6.0",
- "core-foundation",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -1656,17 +2375,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.13.0"
+name = "tagptr"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
-dependencies = [
- "cfg-if",
- "fastrand",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "termcolor"
@@ -1689,7 +2401,16 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.64",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1700,7 +2421,18 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1720,10 +2452,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1731,6 +2465,26 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
 
 [[package]]
 name = "tinytemplate"
@@ -1770,7 +2524,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.7",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -1783,28 +2537,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-openssl"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
-dependencies = [
- "openssl",
- "openssl-sys",
- "tokio",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1833,15 +2566,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
@@ -1849,7 +2573,19 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -1867,12 +2603,64 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -1886,6 +2674,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1899,7 +2688,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1929,108 +2718,16 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "trust-dns-client"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c408c32e6a9dbb38037cece35740f2cf23c875d8ca134d33631cec83f74d3fe"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "lazy_static",
- "openssl",
- "radix_trie",
- "rand",
- "thiserror",
- "time",
- "tokio",
- "tracing",
- "trust-dns-proto",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "openssl",
- "rand",
- "serde",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tokio-openssl",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lazy_static",
- "lru-cache",
- "parking_lot",
- "resolv-conf",
- "serde",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-openssl",
- "tracing",
- "trust-dns-proto",
-]
-
-[[package]]
-name = "trust-dns-server"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99022f9befa6daec2a860be68ac28b1f0d9d7ccf441d8c5a695e35a58d88840d"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "enum-as-inner",
- "futures-executor",
- "futures-util",
- "openssl",
- "serde",
- "thiserror",
- "time",
- "tokio",
- "tokio-openssl",
- "toml 0.5.11",
- "tracing",
- "trust-dns-client",
- "trust-dns-proto",
- "trust-dns-resolver",
 ]
 
 [[package]]
@@ -2041,9 +2738,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typify"
-version = "0.2.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c644dda9862f0fef3a570d8ddb3c2cfb1d5ac824a1f2ddfa7bc8f071a5ad8a"
+checksum = "b715573a376585888b742ead9be5f4826105e622169180662e2c81bed4a149c3"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -2051,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.2.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ab345b6c0d8ae9500b9ff334a4c7c0d316c1c628dc55726b95887eb8dbd11"
+checksum = "a2fd0d27608a466d063d23b97cf2d26c25d838f01b4f7d5ff406a7446f16b6e3"
 dependencies = [
  "heck 0.5.0",
  "log",
@@ -2064,16 +2761,16 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "syn 2.0.79",
- "thiserror",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
  "unicode-ident",
 ]
 
 [[package]]
 name = "typify-macro"
-version = "0.2.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785e2cdcef0df8160fdd762ed548a637aaec1e83704fdbc14da0df66013ee8d0"
+checksum = "fd04bb1207cd4e250941cc1641f4c4815f7eaa2145f45c09dd49cb0a3691710a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2082,30 +2779,15 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn 2.0.79",
+ "syn 2.0.117",
  "typify-impl",
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2121,21 +2803,30 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+dependencies = [
+ "getrandom 0.2.15",
+]
 
 [[package]]
 name = "valuable"
@@ -2156,6 +2847,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2171,48 +2872,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.95"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "cfg-if",
- "once_cell",
- "wasm-bindgen-macro",
+ "wit-bindgen",
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.95"
+name = "wasm-bindgen"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
- "bumpalo",
- "log",
+ "cfg-if",
  "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.79",
+ "rustversion",
+ "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
  "js-sys",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2220,28 +2915,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -2252,12 +2950,40 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.6",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2298,33 +3024,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
+ "windows-link",
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -2352,6 +3092,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2387,6 +3151,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -2399,6 +3169,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -2408,6 +3184,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2429,6 +3211,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -2438,6 +3226,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2453,6 +3247,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -2462,6 +3262,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2485,6 +3291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,6 +3307,41 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -2512,7 +3362,28 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -2527,15 +3398,17 @@ version = "0.6.0-pre1"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap",
+ "clap 3.2.25",
  "ctor",
  "hex",
+ "hickory-dns",
+ "hickory-server",
  "ipnetwork",
  "lazy_static",
- "openssl",
- "rand",
+ "rand 0.8.5",
  "regex",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yml",
@@ -2545,10 +3418,6 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "trust-dns-client",
- "trust-dns-proto",
- "trust-dns-resolver",
- "trust-dns-server",
  "zerotier-api",
 ]
 
@@ -2559,13 +3428,13 @@ dependencies = [
  "anyhow",
  "async-trait",
  "ctor",
+ "hickory-dns",
  "ipnetwork",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
- "trust-dns-resolver",
  "zeronsd",
  "zerotier-api",
 ]
@@ -2582,5 +3451,44 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.79",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3534,6 +3534,7 @@ dependencies = [
  "async-trait",
  "ctor 0.2.9",
  "hickory-dns",
+ "hickory-resolver",
  "ipnetwork",
  "rand 0.8.5",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +770,7 @@ dependencies = [
  "libc",
  "rusqlite",
  "rustls",
+ "rustls-pki-types",
  "serde",
  "socket2 0.5.7",
  "time",
@@ -775,6 +787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
+ "bitflags 2.11.1",
  "bytes",
  "cfg-if",
  "data-encoding",
@@ -794,14 +807,40 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustls",
+ "rustls-pki-types",
  "rustls-platform-verifier 0.5.3",
  "serde",
  "thiserror 2.0.18",
+ "time",
  "tinyvec",
  "tokio",
  "tokio-rustls",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "hickory-recursor"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ec7f3d578a10e8f67a30b3668a324b49c2583e47f04b69ebb32fb735fee41"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "enum-as-inner",
+ "futures-util",
+ "hickory-proto",
+ "hickory-resolver",
+ "ipnet",
+ "lru-cache",
+ "parking_lot",
+ "prefix-trie",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -845,6 +884,7 @@ dependencies = [
  "h3",
  "h3-quinn",
  "hickory-proto",
+ "hickory-recursor",
  "hickory-resolver",
  "http",
  "ipnet",
@@ -1245,6 +1285,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,6 +1311,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "lru-slab"
@@ -3410,7 +3465,9 @@ dependencies = [
  "clap 3.2.25",
  "ctor",
  "hex",
+ "hickory-client",
  "hickory-dns",
+ "hickory-resolver",
  "hickory-server",
  "ipnetwork",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,6 +1949,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,7 +2006,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3409,6 +3418,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,13 +356,30 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "ctor"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95d0d11eb38e7642efca359c3cf6eb7b2e528182d09110165de70192b0352775"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+ "link-section",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ab264ea985f1bd27887d7b21ea2bb046728e05d11909ca138d700c494730db"
 
 [[package]]
 name = "data-encoding"
@@ -389,6 +406,21 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f72721db8027a4e96dd6fb50d2a1d32259c9d3da1b63dee612ccd981e14293"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c98b077c7463d01d22dde8a24378ddf1ca7263dc687cffbed38819ea6c21131"
 
 [[package]]
 name = "dunce"
@@ -1283,6 +1315,12 @@ dependencies = [
  "anyhow",
  "version_check",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "468808413fa8bdf0edbe61c2bbc182dfc59885b94f496cf3fb42c9c96b1e0149"
 
 [[package]]
 name = "linked-hash-map"
@@ -3463,7 +3501,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap 3.2.25",
- "ctor",
+ "ctor 0.10.0",
  "hex",
  "hickory-client",
  "hickory-dns",
@@ -3494,7 +3532,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "ctor",
+ "ctor 0.2.9",
  "hickory-dns",
  "ipnetwork",
  "rand 0.8.5",

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ BSD systems still need a bit of work; work that we could really use your help wi
 
 ## Acknowledgements
 
-ZeroNS demands a lot out of the [trust-dns](https://github.com/bluejekyll/trust-dns) toolkit and I personally am grateful such a library suite exists. It made my job very easy.
+ZeroNS demands a lot out of the [hickory-dns](https://github.com/hickory-dns/hickory-dns) toolkit and I personally am grateful such a library suite exists. It made my job very easy.
 
 ## License
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -19,10 +19,10 @@ path = "integration.rs"
 anyhow = "1.0.89"
 async-trait = "0.1.83"
 ctor = "0.2.8"
+hickory-dns = "0.25.2"
 ipnetwork = "0.20.0"
 rand = "0.8.5"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 tokio = { version = "1.40.0", features = ["rt-multi-thread"] }
 tracing = "0.1.40"
-trust-dns-resolver = "0.22.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -19,7 +19,7 @@ path = "integration.rs"
 anyhow = "1.0.89"
 async-trait = "0.1.83"
 ctor = "0.2.8"
-hickory-dns = "0.25.2"
+hickory-dns = { version = "0.25.2", features = ["dnssec-ring", "tls-ring", "https-ring", "quic-ring", "h3-ring"] }
 ipnetwork = "0.20.0"
 rand = "0.8.5"
 serde = { version = "1.0.210", features = ["derive"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0.89"
 async-trait = "0.1.83"
 ctor = "0.2.8"
 hickory-dns = { version = "0.25.2", features = ["dnssec-ring", "tls-ring", "https-ring", "quic-ring", "h3-ring"] }
+hickory-resolver = { version = "0.25.2", features = ["dnssec-ring", "tls-ring", "https-ring", "quic-ring", "h3-ring"] }
 ipnetwork = "0.20.0"
 rand = "0.8.5"
 serde = { version = "1.0.210", features = ["derive"] }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,7 +14,7 @@ mod sixplane {
 
     use rand::prelude::SliceRandom;
     use tracing::info;
-    use trust_dns_resolver::{IntoName, Name};
+    use hickory_dns_resolver::{IntoName, Name};
 
     use crate::service::{
         resolver::Lookup, to_ip::ToIPv6Vec, utils::HostsType, Service, ServiceConfig,
@@ -159,7 +159,7 @@ mod rfc4193 {
 
     use rand::{prelude::SliceRandom, thread_rng};
     use tracing::info;
-    use trust_dns_resolver::{IntoName, Name};
+    use hickory_dns_resolver::{IntoName, Name};
     use zeronsd::{addresses::Calculator, hosts::parse_hosts};
 
     use crate::service::{
@@ -385,7 +385,7 @@ mod ipv4 {
 
     use std::str::FromStr;
     use tracing::info;
-    use trust_dns_resolver::Name;
+    use hickory_dns_resolver::Name;
 
     use crate::service::{
         resolver::Lookup,
@@ -576,7 +576,7 @@ mod ipv4 {
 mod all {
     use rand::prelude::SliceRandom;
     use tracing::info;
-    use trust_dns_resolver::{IntoName, Name};
+    use hickory_dns_resolver::{IntoName, Name};
 
     use zeronsd::{addresses::Calculator, hosts::parse_hosts, utils::TEST_HOSTS_DIR};
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,7 +14,7 @@ mod sixplane {
 
     use rand::prelude::SliceRandom;
     use tracing::info;
-    use hickory_dns_resolver::{IntoName, Name};
+    use hickory_resolver::{IntoName, Name};
 
     use crate::service::{
         resolver::Lookup, to_ip::ToIPv6Vec, utils::HostsType, Service, ServiceConfig,
@@ -159,7 +159,7 @@ mod rfc4193 {
 
     use rand::{prelude::SliceRandom, thread_rng};
     use tracing::info;
-    use hickory_dns_resolver::{IntoName, Name};
+    use hickory_resolver::{IntoName, Name};
     use zeronsd::{addresses::Calculator, hosts::parse_hosts};
 
     use crate::service::{
@@ -385,7 +385,7 @@ mod ipv4 {
 
     use std::str::FromStr;
     use tracing::info;
-    use hickory_dns_resolver::Name;
+    use hickory_resolver::Name;
 
     use crate::service::{
         resolver::Lookup,
@@ -576,7 +576,7 @@ mod ipv4 {
 mod all {
     use rand::prelude::SliceRandom;
     use tracing::info;
-    use hickory_dns_resolver::{IntoName, Name};
+    use hickory_resolver::{IntoName, Name};
 
     use zeronsd::{addresses::Calculator, hosts::parse_hosts, utils::TEST_HOSTS_DIR};
 

--- a/tests/service/mod.rs
+++ b/tests/service/mod.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use ipnetwork::IpNetwork;
 use rand::prelude::{IteratorRandom, SliceRandom};
 use tracing::info;
-use hickory_dns_resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
+use hickory_resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
 
 use zeronsd::{
     addresses::Calculator,
@@ -136,7 +136,7 @@ impl Service {
             resolver_config.add_name_server(NameServerConfig {
                 bind_addr: None,
                 socket_addr: socket,
-                protocol: hickory_dns_resolver::config::Protocol::Udp,
+                protocol: hickory_resolver::config::Protocol::Udp,
                 tls_dns_name: None,
                 trust_nx_responses: true,
             });
@@ -152,7 +152,7 @@ impl Service {
             opts.negative_max_ttl = Some(Duration::new(0, 0));
 
             resolvers.push(Arc::new(
-                hickory_dns_resolver::TokioAsyncResolver::tokio(resolver_config, opts).unwrap(),
+                hickory_resolver::TokioAsyncResolver::tokio(resolver_config, opts).unwrap(),
             ));
         }
 

--- a/tests/service/mod.rs
+++ b/tests/service/mod.rs
@@ -14,10 +14,13 @@ use std::{
 };
 
 use async_trait::async_trait;
+use hickory_resolver::{
+    config::{NameServerConfig, ResolverConfig, ResolverOpts},
+    name_server::TokioConnectionProvider,
+};
 use ipnetwork::IpNetwork;
 use rand::prelude::{IteratorRandom, SliceRandom};
 use tracing::info;
-use hickory_resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
 
 use zeronsd::{
     addresses::Calculator,
@@ -136,23 +139,30 @@ impl Service {
             resolver_config.add_name_server(NameServerConfig {
                 bind_addr: None,
                 socket_addr: socket,
-                protocol: hickory_resolver::config::Protocol::Udp,
+                protocol: hickory_resolver::proto::xfer::Protocol::Udp,
                 tls_dns_name: None,
-                trust_nx_responses: true,
+                trust_negative_responses: true,
+                http_endpoint: None,
             });
 
             let mut opts = ResolverOpts::default();
             opts.attempts = 10;
             opts.cache_size = 0;
-            opts.rotate = true;
-            opts.use_hosts_file = false;
+            opts.server_ordering_strategy =
+                hickory_resolver::config::ServerOrderingStrategy::RoundRobin;
+            opts.use_hosts_file = hickory_resolver::config::ResolveHosts::Never;
             opts.positive_min_ttl = Some(Duration::new(0, 0));
             opts.positive_max_ttl = Some(Duration::new(0, 0));
             opts.negative_min_ttl = Some(Duration::new(0, 0));
             opts.negative_max_ttl = Some(Duration::new(0, 0));
 
             resolvers.push(Arc::new(
-                hickory_resolver::TokioAsyncResolver::tokio(resolver_config, opts).unwrap(),
+                hickory_resolver::Resolver::builder_with_config(
+                    resolver_config,
+                    TokioConnectionProvider::default(),
+                )
+                .with_options(opts)
+                .build(),
             ));
         }
 
@@ -240,7 +250,7 @@ impl Service {
         for ip in listen_ips.clone() {
             let server = Server::new(ztauthority.to_owned());
             info!("Serving {}", ip.clone());
-            tokio::spawn(server.listen(ip.ip(), Duration::new(1, 0), None, None, None));
+            tokio::spawn(server.listen(ip.ip(), Duration::new(1, 0), None));
         }
 
         listen_ips

--- a/tests/service/mod.rs
+++ b/tests/service/mod.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use ipnetwork::IpNetwork;
 use rand::prelude::{IteratorRandom, SliceRandom};
 use tracing::info;
-use trust_dns_resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
+use hickory_dns_resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
 
 use zeronsd::{
     addresses::Calculator,
@@ -136,7 +136,7 @@ impl Service {
             resolver_config.add_name_server(NameServerConfig {
                 bind_addr: None,
                 socket_addr: socket,
-                protocol: trust_dns_resolver::config::Protocol::Udp,
+                protocol: hickory_dns_resolver::config::Protocol::Udp,
                 tls_dns_name: None,
                 trust_nx_responses: true,
             });
@@ -152,7 +152,7 @@ impl Service {
             opts.negative_max_ttl = Some(Duration::new(0, 0));
 
             resolvers.push(Arc::new(
-                trust_dns_resolver::TokioAsyncResolver::tokio(resolver_config, opts).unwrap(),
+                hickory_dns_resolver::TokioAsyncResolver::tokio(resolver_config, opts).unwrap(),
             ));
         }
 

--- a/tests/service/resolver.rs
+++ b/tests/service/resolver.rs
@@ -4,12 +4,9 @@ use std::{
 };
 
 use async_trait::async_trait;
-use hickory_resolver::{
-    name_server::{GenericConnection, GenericConnectionProvider, TokioRuntime},
-    AsyncResolver,
-};
+use hickory_resolver::{name_server::GenericConnector, proto::runtime::TokioRuntimeProvider};
 
-pub type Resolver = AsyncResolver<GenericConnection, GenericConnectionProvider<TokioRuntime>>;
+pub type Resolver = hickory_resolver::Resolver<GenericConnector<TokioRuntimeProvider>>;
 
 pub type Resolvers = Vec<Arc<Resolver>>;
 
@@ -28,7 +25,7 @@ impl Lookup for Resolver {
             .unwrap()
             .as_lookup()
             .record_iter()
-            .map(|r| r.data().unwrap().clone().into_a().unwrap())
+            .map(|r| r.data().clone().into_a().unwrap().into())
             .collect()
     }
 
@@ -38,7 +35,7 @@ impl Lookup for Resolver {
             .unwrap()
             .as_lookup()
             .record_iter()
-            .map(|r| r.data().unwrap().clone().into_aaaa().unwrap())
+            .map(|r| r.data().clone().into_aaaa().unwrap().into())
             .collect()
     }
 
@@ -48,7 +45,7 @@ impl Lookup for Resolver {
             .unwrap()
             .as_lookup()
             .record_iter()
-            .map(|r| r.data().unwrap().clone().into_ptr().unwrap().to_string())
+            .map(|r| r.data().clone().into_ptr().unwrap().to_string())
             .collect()
     }
 }

--- a/tests/service/resolver.rs
+++ b/tests/service/resolver.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use trust_dns_resolver::{
+use hickory_dns_resolver::{
     name_server::{GenericConnection, GenericConnectionProvider, TokioRuntime},
     AsyncResolver,
 };

--- a/tests/service/resolver.rs
+++ b/tests/service/resolver.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use hickory_dns_resolver::{
+use hickory_resolver::{
     name_server::{GenericConnection, GenericConnectionProvider, TokioRuntime},
     AsyncResolver,
 };

--- a/zeronsd/Cargo.toml
+++ b/zeronsd/Cargo.toml
@@ -20,10 +20,6 @@ regex = "^1.11.0"
 anyhow = "^1.0.89"
 clap = { version = "^3", features = ["derive"] }
 ipnetwork = "^0.20.0"
-trust-dns-client = { version = "^0.22", features = ["dns-over-openssl"] }
-trust-dns-resolver = { version = "^0.22", features = ["tokio-runtime", "dns-over-openssl"] }
-trust-dns-server = { version = "^0.22", features = ["dns-over-openssl"] }
-trust-dns-proto = "^0.22"
 tokio = { version = "1", features = ["full"] }
 serde = "^1.0.210"
 serde_json = "^1.0.128"
@@ -36,19 +32,15 @@ tracing = "^0.1.40"
 tracing-log = "^0.2.0"
 tracing-subscriber = "^0.3.18"
 hex = "^0.4.3"
-openssl = { version = "^0.10.70", features = ["v102", "v110"] }
 async-trait = "^0.1.83"
 lazy_static = "^1.5.0"
-reqwest = "^0.12.8"
-
-[features]
-vendored-openssl = [ "openssl/vendored" ]
+reqwest = "^0.13.2"
+hickory-dns = { version = "0.25.2", features = ["tls-ring", "https-ring", "quic-ring", "h3-ring"] }
+rustls = { version = "^0.23.23", features = ["ring"] }
+hickory-server = { version = "0.25.2", features = ["tls-ring", "https-ring", "quic-ring", "h3-ring"] }
 
 [dev-dependencies]
 ctor = ">=0"
-
-[package.metadata.deb.variants.ubuntu22]
-features = [ "vendored-openssl" ]
 
 [package.metadata.deb]
 copyright = "ZeroTier, Inc"
@@ -75,7 +67,4 @@ ZeroNS provides names that are a part of ZeroTier Central's
 
 [package.metadata.generate-rpm]
 assets = [ { source = "target/release/zeronsd", dest = "/usr/bin/zeronsd", mode = "755" } ]
-features = [ "vendored-openssl" ]
 
-[target.'cfg(windows)'.dependencies]
-openssl = { version = ">=0", features = [ "vendored" ] }

--- a/zeronsd/Cargo.toml
+++ b/zeronsd/Cargo.toml
@@ -38,6 +38,7 @@ reqwest = "^0.13.2"
 hickory-dns = { version = "0.25.2", features = ["tls-ring", "https-ring", "quic-ring", "h3-ring"] }
 rustls = { version = "^0.23.23", features = ["ring"] }
 hickory-server = { version = "0.25.2", features = ["tls-ring", "https-ring", "quic-ring", "h3-ring"] }
+rustls-pemfile = "2.2.0"
 
 [dev-dependencies]
 ctor = ">=0"

--- a/zeronsd/Cargo.toml
+++ b/zeronsd/Cargo.toml
@@ -35,8 +35,8 @@ hex = "^0.4.3"
 async-trait = "^0.1.83"
 lazy_static = "^1.5.0"
 reqwest = "^0.13.2"
-hickory-dns = { version = "0.25.2", features = ["tls-ring", "https-ring", "quic-ring", "h3-ring", "dnssec-ring"] }
-hickory-resolver = { version = "0.25.2", features = ["tls-ring", "https-ring", "quic-ring", "h3-ring", "dnssec-ring"] }
+hickory-dns = { version = "0.25.2", features = ["dnssec-ring", "tls-ring", "https-ring", "quic-ring", "h3-ring"] }
+hickory-resolver = { version = "0.25.2", features = ["dnssec-ring", "tls-ring", "https-ring", "quic-ring", "h3-ring"] }
 hickory-client = { version = "0.25.2", features = ["dnssec-ring", "tls-ring", "https-ring", "quic-ring", "h3-ring"] }
 hickory-server = { version = "0.25.2", features = ["dnssec-ring", "tls-ring", "https-ring", "quic-ring", "h3-ring"] }
 rustls = { version = "^0.23.23", features = ["ring"] }

--- a/zeronsd/Cargo.toml
+++ b/zeronsd/Cargo.toml
@@ -35,9 +35,11 @@ hex = "^0.4.3"
 async-trait = "^0.1.83"
 lazy_static = "^1.5.0"
 reqwest = "^0.13.2"
-hickory-dns = { version = "0.25.2", features = ["tls-ring", "https-ring", "quic-ring", "h3-ring"] }
+hickory-dns = { version = "0.25.2", features = ["tls-ring", "https-ring", "quic-ring", "h3-ring", "dnssec-ring"] }
+hickory-resolver = { version = "0.25.2", features = ["tls-ring", "https-ring", "quic-ring", "h3-ring", "dnssec-ring"] }
+hickory-client = { version = "0.25.2", features = ["dnssec-ring", "tls-ring", "https-ring", "quic-ring", "h3-ring"] }
+hickory-server = { version = "0.25.2", features = ["dnssec-ring", "tls-ring", "https-ring", "quic-ring", "h3-ring"] }
 rustls = { version = "^0.23.23", features = ["ring"] }
-hickory-server = { version = "0.25.2", features = ["tls-ring", "https-ring", "quic-ring", "h3-ring"] }
 rustls-pemfile = "2.2.0"
 
 [dev-dependencies]

--- a/zeronsd/src/authority.rs
+++ b/zeronsd/src/authority.rs
@@ -16,12 +16,12 @@ use crate::{
 
 use async_trait::async_trait;
 use ipnetwork::IpNetwork;
-use trust_dns_resolver::{
+use hickory_dns_resolver::{
     config::NameServerConfigGroup,
     proto::rr::{dnssec::SupportedAlgorithms, rdata::SOA, RData, Record, RecordSet, RecordType},
     IntoName, Name,
 };
-use trust_dns_server::{
+use hickory_server::{
     authority::{AuthorityObject, Catalog},
     client::rr::{LowerName, RrKey},
     store::{
@@ -60,7 +60,7 @@ pub async fn find_members(mut zt: ZTAuthority) {
 pub async fn init_catalog(zt: ZTAuthority) -> Result<Catalog, anyhow::Error> {
     let mut catalog = Catalog::default();
 
-    let resolv = trust_dns_resolver::system_conf::read_system_conf()?;
+    let resolv = hickory_dns_resolver::system_conf::read_system_conf()?;
     let mut nsconfig = NameServerConfigGroup::new();
 
     for server in resolv.0.name_servers() {
@@ -75,7 +75,7 @@ pub async fn init_catalog(zt: ZTAuthority) -> Result<Catalog, anyhow::Error> {
 
     let forwarder = ForwardAuthority::try_from_config(
         Name::root(),
-        trust_dns_server::authority::ZoneType::Primary,
+        hickory_server::authority::ZoneType::Primary,
         config,
     )
     .expect("Could not initialize forwarder");
@@ -291,7 +291,7 @@ impl RecordAuthority {
         let authority = InMemoryAuthority::new(
             domain_name,
             map,
-            trust_dns_server::authority::ZoneType::Primary,
+            hickory_server::authority::ZoneType::Primary,
             false,
         )
         .expect("Could not initialize authority");
@@ -526,8 +526,8 @@ impl AuthorityObject for RecordAuthority {
         Box::new(self.authority.clone())
     }
 
-    fn zone_type(&self) -> trust_dns_server::authority::ZoneType {
-        trust_dns_server::authority::ZoneType::Primary
+    fn zone_type(&self) -> hickory_server::authority::ZoneType {
+        hickory_server::authority::ZoneType::Primary
     }
 
     fn is_axfr_allowed(&self) -> bool {
@@ -536,45 +536,45 @@ impl AuthorityObject for RecordAuthority {
 
     async fn update(
         &self,
-        update: &trust_dns_server::authority::MessageRequest,
-    ) -> trust_dns_server::authority::UpdateResult<bool> {
+        update: &hickory_server::authority::MessageRequest,
+    ) -> hickory_server::authority::UpdateResult<bool> {
         self.authority.update(update).await
     }
 
-    fn origin(&self) -> &trust_dns_server::client::rr::LowerName {
+    fn origin(&self) -> &hickory_server::client::rr::LowerName {
         &self.domain_name
     }
 
     async fn lookup(
         &self,
-        name: &trust_dns_server::client::rr::LowerName,
+        name: &hickory_server::client::rr::LowerName,
         rtype: RecordType,
-        lookup_options: trust_dns_server::authority::LookupOptions,
+        lookup_options: hickory_server::authority::LookupOptions,
     ) -> Result<
-        Box<dyn trust_dns_server::authority::LookupObject>,
-        trust_dns_server::authority::LookupError,
+        Box<dyn hickory_server::authority::LookupObject>,
+        hickory_server::authority::LookupError,
     > {
         self.authority.lookup(name, rtype, lookup_options).await
     }
 
     async fn search(
         &self,
-        request_info: trust_dns_server::server::RequestInfo<'_>,
-        lookup_options: trust_dns_server::authority::LookupOptions,
+        request_info: hickory_server::server::RequestInfo<'_>,
+        lookup_options: hickory_server::authority::LookupOptions,
     ) -> Result<
-        Box<dyn trust_dns_server::authority::LookupObject>,
-        trust_dns_server::authority::LookupError,
+        Box<dyn hickory_server::authority::LookupObject>,
+        hickory_server::authority::LookupError,
     > {
         self.authority.search(request_info, lookup_options).await
     }
 
     async fn get_nsec_records(
         &self,
-        name: &trust_dns_server::client::rr::LowerName,
-        lookup_options: trust_dns_server::authority::LookupOptions,
+        name: &hickory_server::client::rr::LowerName,
+        lookup_options: hickory_server::authority::LookupOptions,
     ) -> Result<
-        Box<dyn trust_dns_server::authority::LookupObject>,
-        trust_dns_server::authority::LookupError,
+        Box<dyn hickory_server::authority::LookupObject>,
+        hickory_server::authority::LookupError,
     > {
         self.authority.get_nsec_records(name, lookup_options).await
     }

--- a/zeronsd/src/authority.rs
+++ b/zeronsd/src/authority.rs
@@ -15,20 +15,20 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use ipnetwork::IpNetwork;
-use hickory_dns_resolver::{
-    config::NameServerConfigGroup,
-    proto::rr::{dnssec::SupportedAlgorithms, rdata::SOA, RData, Record, RecordSet, RecordType},
-    IntoName, Name,
+use hickory_resolver::{config::NameServerConfigGroup, IntoName, Name};
+use hickory_server::{
+    authority::LookupControlFlow,
+    proto::rr::{rdata, RData, Record, RecordSet, RecordType},
 };
 use hickory_server::{
     authority::{AuthorityObject, Catalog},
-    client::rr::{LowerName, RrKey},
+    proto::rr::{LowerName, RrKey},
     store::{
         forwarder::{ForwardAuthority, ForwardConfig},
         in_memory::InMemoryAuthority,
     },
 };
+use ipnetwork::IpNetwork;
 
 use zerotier_api::central_api;
 
@@ -60,7 +60,7 @@ pub async fn find_members(mut zt: ZTAuthority) {
 pub async fn init_catalog(zt: ZTAuthority) -> Result<Catalog, anyhow::Error> {
     let mut catalog = Catalog::default();
 
-    let resolv = hickory_dns_resolver::system_conf::read_system_conf()?;
+    let resolv = hickory_resolver::system_conf::read_system_conf()?;
     let mut nsconfig = NameServerConfigGroup::new();
 
     for server in resolv.0.name_servers() {
@@ -68,27 +68,28 @@ pub async fn init_catalog(zt: ZTAuthority) -> Result<Catalog, anyhow::Error> {
     }
 
     let options = Some(resolv.1);
-    let config = &ForwardConfig {
+    let config = ForwardConfig {
         name_servers: nsconfig.clone(),
         options,
     };
 
-    let forwarder = ForwardAuthority::try_from_config(
-        Name::root(),
-        hickory_server::authority::ZoneType::Primary,
-        config,
-    )
-    .expect("Could not initialize forwarder");
+    // ABEL TODO: Used to set zone_type to hickory_server::authority::ZoneType::Primary, can't do that now.
+    let forwarder = ForwardAuthority::builder_tokio(config)
+        .with_origin(Name::root())
+        .build()
+        .expect("Could not initialize forwarder");
 
-    catalog.upsert(Name::root().into(), Box::new(Arc::new(forwarder)));
+    catalog.upsert(Name::root().into(), vec![Arc::new(forwarder)]);
 
     catalog.upsert(
         zt.forward_authority.domain_name.clone(),
-        zt.forward_authority.box_clone(),
+        // ABEL TODO: Used to do box_clone(), is Arc::new the same?
+        vec![Arc::new(zt.forward_authority)],
     );
 
     for (network, authority) in zt.reverse_authority_map {
-        catalog.upsert(network.to_ptr_soa_name()?, authority.box_clone())
+        // ABEL TODO: Used to do box_clone(), is Arc::new the same?
+        catalog.upsert(network.to_ptr_soa_name()?, vec![Arc::new(authority)]);
     }
 
     Ok(catalog)
@@ -259,9 +260,9 @@ impl RecordAuthority {
         member_name: Name,
     ) -> Result<InMemoryAuthority, anyhow::Error> {
         let mut map = BTreeMap::new();
-        let mut soa = Record::with(domain_name.clone(), RecordType::SOA, 30);
+        let mut soa = Record::update0(domain_name.clone(), 30, RecordType::SOA);
 
-        soa.set_data(Some(RData::SOA(SOA::new(
+        soa.set_data(RData::SOA(rdata::SOA::new(
             domain_name.clone(),
             Name::from_str("administrator")?.append_domain(&domain_name)?,
             1,
@@ -269,18 +270,18 @@ impl RecordAuthority {
             0,
             -1,
             0,
-        ))));
+        )));
 
-        let mut soa_rs = RecordSet::new(&domain_name, RecordType::SOA, 1);
+        let mut soa_rs = RecordSet::new(domain_name.clone(), RecordType::SOA, 1);
         soa_rs.insert(soa, 1);
         map.insert(
             RrKey::new(domain_name.clone().into(), RecordType::SOA),
             soa_rs,
         );
 
-        let mut ns = Record::with(domain_name.clone(), RecordType::NS, 30);
-        ns.set_data(Some(RData::NS(member_name)));
-        let mut ns_rs = RecordSet::new(&domain_name, RecordType::NS, 1);
+        let mut ns = Record::update0(domain_name.clone(), 30, RecordType::NS);
+        ns.set_data(RData::NS(rdata::NS(member_name)));
+        let mut ns_rs = RecordSet::new(domain_name.clone(), RecordType::NS, 1);
         ns_rs.insert(ns, 1);
 
         map.insert(
@@ -293,6 +294,7 @@ impl RecordAuthority {
             map,
             hickory_server::authority::ZoneType::Primary,
             false,
+            None,
         )
         .expect("Could not initialize authority");
 
@@ -302,8 +304,8 @@ impl RecordAuthority {
     async fn replace_ip_record(&self, fqdn: Name, rdatas: Vec<RData>) {
         let serial = self.authority.serial().await;
         for rdata in rdatas {
-            let mut address = Record::with(fqdn.clone(), rdata.to_record_type(), 60);
-            address.set_data(Some(rdata.clone()));
+            let mut address = Record::update0(fqdn.clone(), 60, rdata.record_type());
+            address.set_data(rdata.clone());
             tracing::info!("Adding new record {}: ({})", fqdn.clone(), rdata);
             self.authority.upsert(address, serial).await;
         }
@@ -328,7 +330,7 @@ impl RecordAuthority {
         for (host, ips) in hosts_map.into_iter() {
             for (rrkey, rset) in rr.clone() {
                 let key = &rrkey.name().into_name().expect("could not parse name");
-                let records = rset.records(false, SupportedAlgorithms::all());
+                let records = rset.records(false);
 
                 let rt = rset.record_type();
                 let rdatas: Vec<RData> = ips
@@ -337,14 +339,14 @@ impl RecordAuthority {
                     .filter_map(|i| match i {
                         IpAddr::V4(ip) => {
                             if rt == RecordType::A {
-                                Some(RData::A(ip))
+                                Some(RData::A(rdata::A(ip)))
                             } else {
                                 None
                             }
                         }
                         IpAddr::V6(ip) => {
                             if rt == RecordType::AAAA {
-                                Some(RData::AAAA(ip))
+                                Some(RData::AAAA(rdata::AAAA(ip)))
                             } else {
                                 None
                             }
@@ -354,11 +356,9 @@ impl RecordAuthority {
 
                 if key.eq(&host)
                     && (records.is_empty()
-                        || !records
-                            .map(|r| r.data().unwrap())
-                            .all(|rd| rdatas.contains(rd)))
+                        || !records.map(|r| r.data()).all(|rd| rdatas.contains(rd)))
                 {
-                    let mut new_rset = RecordSet::new(key, rt, serial);
+                    let mut new_rset = RecordSet::new(key.clone(), rt, serial);
                     for rdata in rdatas.clone() {
                         new_rset.add_rdata(rdata);
                     }
@@ -397,8 +397,8 @@ impl RecordAuthority {
         let rdatas: Vec<RData> = ips
             .iter()
             .map(|&ip| match ip {
-                IpAddr::V4(ip) => RData::A(ip),
-                IpAddr::V6(ip) => RData::AAAA(ip),
+                IpAddr::V4(ip) => RData::A(rdata::A(ip)),
+                IpAddr::V6(ip) => RData::AAAA(rdata::AAAA(ip)),
             })
             .collect();
 
@@ -422,7 +422,7 @@ impl RecordAuthority {
                     if name_records.is_empty()
                         || !name_records
                             .records_without_rrsigs()
-                            .all(|r| rdatas.clone().contains(r.data().unwrap()))
+                            .all(|r| rdatas.clone().contains(r.data()))
                             && !type_ips.is_empty()
                     {
                         self.replace_ip_record(name.clone(), rdatas.clone()).await;
@@ -488,7 +488,7 @@ impl RecordAuthority {
             Some(records) => {
                 if !records
                     .records_without_rrsigs()
-                    .any(|rec| rec.data().unwrap().eq(&RData::PTR(fqdn.clone())))
+                    .any(|rec| rec.data().eq(&RData::PTR(rdata::PTR(fqdn.clone()))))
                 {
                     self.set_ptr_record(ptr.clone(), fqdn.clone()).await;
                 }
@@ -513,8 +513,8 @@ impl RecordAuthority {
         drop(records);
 
         let serial = self.authority.serial().await;
-        let mut address = Record::with(ptr.clone(), RecordType::PTR, 60);
-        address.set_data(Some(RData::PTR(fqdn.clone())));
+        let mut address = Record::update0(ptr.clone(), 60, RecordType::PTR);
+        address.set_data(RData::PTR(rdata::PTR(fqdn.clone())));
 
         self.authority.upsert(address, serial).await;
     }
@@ -522,16 +522,17 @@ impl RecordAuthority {
 
 #[async_trait]
 impl AuthorityObject for RecordAuthority {
-    fn box_clone(&self) -> Box<dyn AuthorityObject> {
-        Box::new(self.authority.clone())
-    }
-
     fn zone_type(&self) -> hickory_server::authority::ZoneType {
         hickory_server::authority::ZoneType::Primary
     }
 
     fn is_axfr_allowed(&self) -> bool {
         false
+    }
+
+    fn can_validate_dnssec(&self) -> bool {
+        // ABEL TODO: Maybe false?
+        self.authority.can_validate_dnssec()
     }
 
     async fn update(
@@ -541,27 +542,39 @@ impl AuthorityObject for RecordAuthority {
         self.authority.update(update).await
     }
 
-    fn origin(&self) -> &hickory_server::client::rr::LowerName {
+    fn origin(&self) -> &hickory_server::proto::rr::LowerName {
         &self.domain_name
     }
 
     async fn lookup(
         &self,
-        name: &hickory_server::client::rr::LowerName,
+        name: &hickory_server::proto::rr::LowerName,
         rtype: RecordType,
         lookup_options: hickory_server::authority::LookupOptions,
-    ) -> Result<
+    ) -> LookupControlFlow<
         Box<dyn hickory_server::authority::LookupObject>,
         hickory_server::authority::LookupError,
     > {
         self.authority.lookup(name, rtype, lookup_options).await
     }
 
+    async fn consult(
+        &self,
+        name: &LowerName,
+        rtype: RecordType,
+        lookup_options: hickory_server::authority::LookupOptions,
+        last_result: LookupControlFlow<Box<dyn hickory_server::authority::LookupObject>>,
+    ) -> LookupControlFlow<Box<dyn hickory_server::authority::LookupObject>> {
+        self.authority
+            .consult(name, rtype, lookup_options, last_result)
+            .await
+    }
+
     async fn search(
         &self,
         request_info: hickory_server::server::RequestInfo<'_>,
         lookup_options: hickory_server::authority::LookupOptions,
-    ) -> Result<
+    ) -> LookupControlFlow<
         Box<dyn hickory_server::authority::LookupObject>,
         hickory_server::authority::LookupError,
     > {
@@ -570,13 +583,28 @@ impl AuthorityObject for RecordAuthority {
 
     async fn get_nsec_records(
         &self,
-        name: &hickory_server::client::rr::LowerName,
+        name: &hickory_server::proto::rr::LowerName,
         lookup_options: hickory_server::authority::LookupOptions,
-    ) -> Result<
+    ) -> LookupControlFlow<
         Box<dyn hickory_server::authority::LookupObject>,
         hickory_server::authority::LookupError,
     > {
         self.authority.get_nsec_records(name, lookup_options).await
+    }
+
+    async fn get_nsec3_records(
+        &self,
+        info: hickory_server::authority::Nsec3QueryInfo<'_>,
+        lookup_options: hickory_server::authority::LookupOptions,
+    ) -> LookupControlFlow<
+        Box<dyn hickory_server::authority::LookupObject>,
+        hickory_server::authority::LookupError,
+    > {
+        self.authority.get_nsec3_records(info, lookup_options).await
+    }
+
+    fn nx_proof_kind(&self) -> Option<&hickory_server::dnssec::NxProofKind> {
+        self.authority.nx_proof_kind()
     }
 }
 

--- a/zeronsd/src/authority.rs
+++ b/zeronsd/src/authority.rs
@@ -147,7 +147,7 @@ impl ZTAuthority {
 
         let v6assign = network.config.clone().unwrap().v6_assign_mode;
         if let Some(v6assign) = v6assign {
-            if v6assign._6plane.unwrap_or(false) {
+            if v6assign.x6plane.unwrap_or(false) {
                 let s = network.clone().sixplane()?;
                 sixplane = Some(s);
             }

--- a/zeronsd/src/hosts.rs
+++ b/zeronsd/src/hosts.rs
@@ -6,7 +6,7 @@ use std::{
     str::FromStr,
 };
 use tracing::warn;
-use trust_dns_server::client::rr::Name;
+use hickory_server::client::rr::Name;
 
 use crate::traits::ToHostname;
 

--- a/zeronsd/src/hosts.rs
+++ b/zeronsd/src/hosts.rs
@@ -6,7 +6,7 @@ use std::{
     str::FromStr,
 };
 use tracing::warn;
-use hickory_server::client::rr::Name;
+use hickory_server::proto::rr::Name;
 
 use crate::traits::ToHostname;
 

--- a/zeronsd/src/init.rs
+++ b/zeronsd/src/init.rs
@@ -214,12 +214,13 @@ impl Launcher {
                         let leaf_cert = {
                             let pem = std::fs::read(&cert_path)?;
                             let mut reader = BufReader::new(pem.as_slice());
-                            rustls_pemfile::certs(&mut reader)
+                            let certs = rustls_pemfile::certs(&mut reader)
                                 .next()
                                 .transpose()?
                                 .ok_or_else(|| {
                                     anyhow!("no certificate found in {}", cert_path.display())
-                                })?
+                                })?;
+                            certs
                         };
 
                         let mut cert_chain = vec![leaf_cert];

--- a/zeronsd/src/init.rs
+++ b/zeronsd/src/init.rs
@@ -172,7 +172,7 @@ impl Launcher {
                 .await?;
 
             if let Some(v6assign) = network.config.clone().unwrap().v6_assign_mode {
-                if v6assign._6plane.unwrap_or(false) {
+                if v6assign.x6plane.unwrap_or(false) {
                     warn!("6PLANE PTR records are not yet supported");
                 }
 

--- a/zeronsd/src/init.rs
+++ b/zeronsd/src/init.rs
@@ -1,7 +1,9 @@
 use std::{
     collections::{hash_map::Entry, HashMap},
+    io::BufReader,
     path::PathBuf,
     str::FromStr,
+    sync::Arc,
     time::Duration,
 };
 
@@ -10,7 +12,10 @@ use ipnetwork::IpNetwork;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use rustls::{pkey::PKey, stack::Stack, x509::X509};
+use rustls::{
+    server::ResolvesServerCert,
+    sign::{CertifiedKey, SingleCertAndKey},
+};
 
 use crate::{
     addresses::*,
@@ -200,40 +205,56 @@ impl Launcher {
             tokio::spawn(find_members(ztauthority.clone()));
 
             let server = Server::new(ztauthority.to_owned());
+
+            let tls_resolver: Option<Arc<dyn ResolvesServerCert>> =
+                match (self.tls_cert.clone(), self.tls_key.clone()) {
+                    (Some(cert_path), Some(key_path)) => {
+                        let provider = rustls::crypto::ring::default_provider();
+
+                        let leaf_cert = {
+                            let pem = std::fs::read(&cert_path)?;
+                            let mut reader = BufReader::new(pem.as_slice());
+                            rustls_pemfile::certs(&mut reader)
+                                .next()
+                                .transpose()?
+                                .ok_or_else(|| {
+                                    anyhow!("no certificate found in {}", cert_path.display())
+                                })?
+                        };
+
+                        let mut cert_chain = vec![leaf_cert];
+
+                        if let Some(chain_path) = self.chain_cert.clone() {
+                            let pem = std::fs::read(&chain_path)?;
+                            let mut reader = BufReader::new(pem.as_slice());
+                            cert_chain.extend(
+                                rustls_pemfile::certs(&mut reader)
+                                    .collect::<Result<Vec<_>, _>>()?,
+                            );
+                        }
+
+                        let key = {
+                            let pem = std::fs::read(&key_path)?;
+                            let mut reader = BufReader::new(pem.as_slice());
+                            rustls_pemfile::private_key(&mut reader)?.ok_or_else(|| {
+                                anyhow!("no private key found in {}", key_path.display())
+                            })?
+                        };
+
+                        let certified_key = CertifiedKey::from_der(cert_chain, key, &provider)?;
+                        Some(Arc::new(SingleCertAndKey::from(Arc::new(certified_key)))
+                            as Arc<dyn ResolvesServerCert>)
+                    }
+                    _ => None,
+                };
+
             for ip in listen_ips {
                 info!("Your IP for this network: {}", ip);
-
-                let tls_cert = if let Some(tls_cert) = self.tls_cert.clone() {
-                    let pem = std::fs::read(tls_cert)?;
-                    Some(X509::from_pem(&pem)?)
-                } else {
-                    None
-                };
-
-                let chain = if let Some(chain_cert) = self.chain_cert.clone() {
-                    let pem = std::fs::read(chain_cert)?;
-                    let chain = X509::stack_from_pem(&pem)?;
-
-                    let mut stack = Stack::new()?;
-                    for cert in chain {
-                        stack.push(cert)?;
-                    }
-                    Some(stack)
-                } else {
-                    None
-                };
-
-                let key = if let Some(key_path) = self.tls_key.clone() {
-                    let pem = std::fs::read(key_path)?;
-                    Some(PKey::private_key_from_pem(&pem)?)
-                } else {
-                    None
-                };
 
                 tokio::spawn(
                     server
                         .clone()
-                        .listen(ip, Duration::new(1, 0), tls_cert, chain, key),
+                        .listen(ip, Duration::new(1, 0), tls_resolver.clone()),
                 );
             }
 

--- a/zeronsd/src/init.rs
+++ b/zeronsd/src/init.rs
@@ -10,7 +10,7 @@ use ipnetwork::IpNetwork;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use openssl::{pkey::PKey, stack::Stack, x509::X509};
+use rustls::{pkey::PKey, stack::Stack, x509::X509};
 
 use crate::{
     addresses::*,

--- a/zeronsd/src/server.rs
+++ b/zeronsd/src/server.rs
@@ -1,14 +1,11 @@
 use std::{
     net::{IpAddr, SocketAddr},
+    sync::Arc,
     time::Duration,
 };
 use tracing::info;
 
-use rustls::{
-    pkey::{PKey, Private},
-    stack::Stack,
-    x509::X509,
-};
+use rustls::server::ResolvesServerCert;
 use tokio::net::{TcpListener, UdpSocket};
 
 use hickory_server::server::ServerFuture;
@@ -28,9 +25,7 @@ impl Server {
         self,
         ip: IpAddr,
         tcp_timeout: Duration,
-        certs: Option<X509>,
-        cert_chain: Option<Stack<X509>>,
-        key: Option<PKey<Private>>,
+        tls_resolver: Option<Arc<dyn ResolvesServerCert>>,
     ) -> Result<(), anyhow::Error> {
         let sa = SocketAddr::new(ip, 53);
         let tcp = TcpListener::bind(sa).await?;
@@ -38,11 +33,11 @@ impl Server {
 
         let mut sf = ServerFuture::new(init_catalog(self.0).await?);
 
-        if let (Some(certs), Some(key)) = (certs.clone(), key.clone()) {
+        if let Some(tls_resolver) = tls_resolver {
             info!("Configuring DoT Listener");
             let tls = TcpListener::bind(SocketAddr::new(ip, 853)).await?;
 
-            match sf.register_tls_listener(tls, tcp_timeout, ((certs, cert_chain), key)) {
+            match sf.register_tls_listener(tls, tcp_timeout, tls_resolver) {
                 Ok(_) => {}
                 Err(e) => tracing::error!("Cannot start DoT listener: {}", e),
             }

--- a/zeronsd/src/server.rs
+++ b/zeronsd/src/server.rs
@@ -4,14 +4,14 @@ use std::{
 };
 use tracing::info;
 
-use openssl::{
+use rustls::{
     pkey::{PKey, Private},
     stack::Stack,
     x509::X509,
 };
 use tokio::net::{TcpListener, UdpSocket};
 
-use trust_dns_server::server::ServerFuture;
+use hickory_server::server::ServerFuture;
 
 use crate::authority::{init_catalog, ZTAuthority};
 

--- a/zeronsd/src/supervise.rs
+++ b/zeronsd/src/supervise.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 use regex::Regex;
 use serde::Serialize;
 use tinytemplate::TinyTemplate;
-use trust_dns_resolver::Name;
+use hickory_dns_resolver::Name;
 
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::PermissionsExt;

--- a/zeronsd/src/supervise.rs
+++ b/zeronsd/src/supervise.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 use regex::Regex;
 use serde::Serialize;
 use tinytemplate::TinyTemplate;
-use hickory_dns_resolver::Name;
+use hickory_resolver::Name;
 
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::PermissionsExt;

--- a/zeronsd/src/tests.rs
+++ b/zeronsd/src/tests.rs
@@ -76,7 +76,7 @@ fn test_parse_ip_from_cidr() {
 #[test]
 fn test_domain_or_default() {
     use crate::utils::{domain_or_default, DEFAULT_DOMAIN_NAME};
-    use hickory_server::client::rr::Name;
+    use hickory_server::proto::rr::Name;
 
     assert_eq!(
         domain_or_default(None).unwrap(),
@@ -325,7 +325,7 @@ fn test_parse_hosts() {
     use crate::hosts::parse_hosts;
     use std::net::IpAddr;
     use std::str::FromStr;
-    use hickory_dns_resolver::Name;
+    use hickory_resolver::Name;
 
     let domain = &Name::from_str("zombocom").unwrap();
 
@@ -386,7 +386,7 @@ fn test_parse_hosts() {
 #[test]
 fn test_parse_hosts_duplicate() {
     use crate::hosts::parse_hosts;
-    use hickory_dns_resolver::Name;
+    use hickory_resolver::Name;
 
     let domain = Name::from_str("zombocom").unwrap();
 

--- a/zeronsd/src/tests.rs
+++ b/zeronsd/src/tests.rs
@@ -76,7 +76,7 @@ fn test_parse_ip_from_cidr() {
 #[test]
 fn test_domain_or_default() {
     use crate::utils::{domain_or_default, DEFAULT_DOMAIN_NAME};
-    use trust_dns_server::client::rr::Name;
+    use hickory_server::client::rr::Name;
 
     assert_eq!(
         domain_or_default(None).unwrap(),
@@ -325,7 +325,7 @@ fn test_parse_hosts() {
     use crate::hosts::parse_hosts;
     use std::net::IpAddr;
     use std::str::FromStr;
-    use trust_dns_resolver::Name;
+    use hickory_dns_resolver::Name;
 
     let domain = &Name::from_str("zombocom").unwrap();
 
@@ -386,7 +386,7 @@ fn test_parse_hosts() {
 #[test]
 fn test_parse_hosts_duplicate() {
     use crate::hosts::parse_hosts;
-    use trust_dns_resolver::Name;
+    use hickory_dns_resolver::Name;
 
     let domain = Name::from_str("zombocom").unwrap();
 

--- a/zeronsd/src/tests.rs
+++ b/zeronsd/src/tests.rs
@@ -85,12 +85,12 @@ fn test_domain_or_default() {
 
     assert_eq!(
         domain_or_default(Some("zerotier")).unwrap(),
-        Name::from_str("zerotier").unwrap()
+        Name::from_str("zerotier.").unwrap()
     );
 
     assert_eq!(
         domain_or_default(Some("zerotier.tld")).unwrap(),
-        Name::from_str("zerotier.tld").unwrap()
+        Name::from_str("zerotier.tld.").unwrap()
     );
 
     for bad in ["bad.", "~", "!", ".", ""] {

--- a/zeronsd/src/traits.rs
+++ b/zeronsd/src/traits.rs
@@ -113,31 +113,31 @@ mod tests {
         for item in vec![
             (
                 IpNetwork::from_str("1.2.3.4/24").unwrap(),
-                LowerName::from_str("3.2.1.in-addr.arpa").unwrap(),
+                LowerName::from_str("3.2.1.in-addr.arpa.").unwrap(),
             ),
             (
                 IpNetwork::from_str("1.2.3.4/16").unwrap(),
-                LowerName::from_str("2.1.in-addr.arpa").unwrap(),
+                LowerName::from_str("2.1.in-addr.arpa.").unwrap(),
             ),
             (
                 IpNetwork::from_str("1.2.3.4/8").unwrap(),
-                LowerName::from_str("1.in-addr.arpa").unwrap(),
+                LowerName::from_str("1.in-addr.arpa.").unwrap(),
             ),
             (
                 IpNetwork::from_str("1.2.3.4/12").unwrap(),
-                LowerName::from_str("1.in-addr.arpa").unwrap(),
+                LowerName::from_str("1.in-addr.arpa.").unwrap(),
             ),
             (
                 IpNetwork::from_str("1.2.3.4/22").unwrap(),
-                LowerName::from_str("2.1.in-addr.arpa").unwrap(),
+                LowerName::from_str("2.1.in-addr.arpa.").unwrap(),
             ),
             (
                 IpNetwork::from_str("1.2.3.4/26").unwrap(),
-                LowerName::from_str("3.2.1.in-addr.arpa").unwrap(),
+                LowerName::from_str("3.2.1.in-addr.arpa.").unwrap(),
             ),
             (
                 IpNetwork::from_str("1.2.3.4/32").unwrap(),
-                LowerName::from_str("4.3.2.1.in-addr.arpa").unwrap(),
+                LowerName::from_str("4.3.2.1.in-addr.arpa.").unwrap(),
             ),
         ] {
             assert_eq!(item.0.to_ptr_soa_name().unwrap(), item.1);
@@ -176,7 +176,7 @@ mod tests {
         let fqdn = member
             .to_fqdn(Name::from_str("home.arpa").unwrap())
             .unwrap();
-        assert_eq!(fqdn, Name::from_str("zt-foo.home.arpa").unwrap());
+        assert_eq!(fqdn, Name::from_str("zt-foo.home.arpa.").unwrap());
 
         member.node_id = Some("Joe Sixpack's iMac".to_string());
         let hostname = member.to_hostname().unwrap();
@@ -186,7 +186,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             fqdn,
-            Name::from_str("zt-joe-sixpacks-imac.home.arpa").unwrap()
+            Name::from_str("zt-joe-sixpacks-imac.home.arpa.").unwrap()
         );
 
         member.node_id = Some("abc.".to_string());
@@ -201,7 +201,7 @@ mod tests {
         let hostname = "foo".to_hostname().unwrap();
         assert_eq!(hostname, Name::from_str("foo").unwrap());
         let fqdn = "foo".to_fqdn(Name::from_str("home.arpa").unwrap()).unwrap();
-        assert_eq!(fqdn, Name::from_str("foo.home.arpa").unwrap());
+        assert_eq!(fqdn, Name::from_str("foo.home.arpa.").unwrap());
 
         let hostname = "foo".to_string().to_hostname().unwrap();
         assert_eq!(hostname, Name::from_str("foo").unwrap());
@@ -209,14 +209,14 @@ mod tests {
             .to_string()
             .to_fqdn(Name::from_str("home.arpa").unwrap())
             .unwrap();
-        assert_eq!(fqdn, Name::from_str("foo.home.arpa").unwrap());
+        assert_eq!(fqdn, Name::from_str("foo.home.arpa.").unwrap());
 
         let hostname = "Joe Sixpack's iMac".to_hostname().unwrap();
         assert_eq!(hostname, Name::from_str("joe-sixpacks-imac").unwrap());
         let fqdn = "Joe Sixpack's iMac"
             .to_fqdn(Name::from_str("home.arpa").unwrap())
             .unwrap();
-        assert_eq!(fqdn, Name::from_str("joe-sixpacks-imac.home.arpa").unwrap());
+        assert_eq!(fqdn, Name::from_str("joe-sixpacks-imac.home.arpa.").unwrap());
 
         let hostname = "Joe Sixpack's iMac".to_string().to_hostname().unwrap();
         assert_eq!(hostname, Name::from_str("joe-sixpacks-imac").unwrap());
@@ -224,7 +224,7 @@ mod tests {
             .to_string()
             .to_fqdn(Name::from_str("home.arpa").unwrap())
             .unwrap();
-        assert_eq!(fqdn, Name::from_str("joe-sixpacks-imac.home.arpa").unwrap());
+        assert_eq!(fqdn, Name::from_str("joe-sixpacks-imac.home.arpa.").unwrap());
 
         assert!("abc.".to_hostname().is_err());
         assert!("abc."

--- a/zeronsd/src/traits.rs
+++ b/zeronsd/src/traits.rs
@@ -4,8 +4,8 @@ use anyhow::anyhow;
 use ipnetwork::IpNetwork;
 use lazy_static::lazy_static;
 use regex::Regex;
-use hickory_dns_resolver::{proto::error::ProtoError, IntoName, Name};
-use hickory_server::client::rr::LowerName;
+use hickory_resolver::{proto::error::ProtoError, IntoName, Name};
+use hickory_server::proto::rr::LowerName;
 use zerotier_api::central_api::types::Member;
 
 pub trait ToPointerSOA {
@@ -104,8 +104,8 @@ mod tests {
 
     use super::{ToHostname, ToPointerSOA, ToWildcard};
     use ipnetwork::IpNetwork;
-    use hickory_dns_resolver::Name;
-    use hickory_server::client::rr::LowerName;
+    use hickory_resolver::Name;
+    use hickory_server::proto::rr::LowerName;
     use zerotier_api::central_api::types::Member;
 
     #[test]

--- a/zeronsd/src/traits.rs
+++ b/zeronsd/src/traits.rs
@@ -4,8 +4,8 @@ use anyhow::anyhow;
 use ipnetwork::IpNetwork;
 use lazy_static::lazy_static;
 use regex::Regex;
-use trust_dns_resolver::{proto::error::ProtoError, IntoName, Name};
-use trust_dns_server::client::rr::LowerName;
+use hickory_dns_resolver::{proto::error::ProtoError, IntoName, Name};
+use hickory_server::client::rr::LowerName;
 use zerotier_api::central_api::types::Member;
 
 pub trait ToPointerSOA {
@@ -73,7 +73,7 @@ impl ToHostname for Member {
 }
 
 impl ToHostname for String {
-    // to_hostname turns member names into trust-dns compatible dns names.
+    // to_hostname turns member names into hickory-dns compatible dns names.
     fn to_hostname(&self) -> Result<Name, anyhow::Error> {
         let mut s = self.trim().to_string();
         for (regex, replacement) in TRANSLATION_TABLE.iter() {
@@ -104,8 +104,8 @@ mod tests {
 
     use super::{ToHostname, ToPointerSOA, ToWildcard};
     use ipnetwork::IpNetwork;
-    use trust_dns_resolver::Name;
-    use trust_dns_server::client::rr::LowerName;
+    use hickory_dns_resolver::Name;
+    use hickory_server::client::rr::LowerName;
     use zerotier_api::central_api::types::Member;
 
     #[test]

--- a/zeronsd/src/traits.rs
+++ b/zeronsd/src/traits.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 use ipnetwork::IpNetwork;
 use lazy_static::lazy_static;
 use regex::Regex;
-use hickory_resolver::{proto::error::ProtoError, IntoName, Name};
+use hickory_resolver::{proto::ProtoError, IntoName, Name};
 use hickory_server::proto::rr::LowerName;
 use zerotier_api::central_api::types::Member;
 

--- a/zeronsd/src/utils.rs
+++ b/zeronsd/src/utils.rs
@@ -3,7 +3,7 @@ use std::{net::IpAddr, path::Path, str::FromStr, sync::Once};
 use ipnetwork::IpNetwork;
 use reqwest::header::{HeaderMap, HeaderValue};
 use tracing::warn;
-use trust_dns_server::client::rr::{LowerName, Name};
+use hickory_server::client::rr::{LowerName, Name};
 
 use anyhow::anyhow;
 

--- a/zeronsd/src/utils.rs
+++ b/zeronsd/src/utils.rs
@@ -3,7 +3,7 @@ use std::{net::IpAddr, path::Path, str::FromStr, sync::Once};
 use ipnetwork::IpNetwork;
 use reqwest::header::{HeaderMap, HeaderValue};
 use tracing::warn;
-use hickory_server::client::rr::{LowerName, Name};
+use hickory_server::proto::rr::{LowerName, Name};
 
 use anyhow::anyhow;
 

--- a/zerotier-api/Cargo.toml
+++ b/zerotier-api/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3.31"
-progenitor-client = "0.8.0"
-reqwest = "0.12.8"
+progenitor-client = "0.13.0"
+reqwest = "^0.13.2"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.130"
 
 [build-dependencies]
 anyhow = "1.0.90"
 prettyplease = "0.2.22"
-progenitor = "0.8.0"
+progenitor = "0.13.0"
 serde_json = "1.0.130"
 syn = "2.0.79"
 serde = { version = "1.0.210", features = ["derive"] }


### PR DESCRIPTION
I stumbled across a bug in ZeroNSD where wildcard mode (`-w`) only affected one level of nested domains, not arbitrarily many (as RFC 1034 demands). After a bit of investigation, I traced it to hickory-dns (previously trust-dns), the underlying DNS server implementation ZeroNSD depends on. After a bit more investigation, it turned out this was a known bug, and after a bit more still, that it was already fixed without anyone noticing (see hickory-dns/hickory-dns#1342). So I decided to update the dependency and rebuild ZeroNSD with it.

The package names were changed, as well as a lot of the internals (feature flags, method names, architectural patterns). I also finished the transition from openssl entirely to rustls (the current revision depended on both). I had to edit some unit tests by including a trailing dot in the expected resulting domain names (it seems the previous version of hickory-dns accepted names with and without the dot as equal). Other than that all unit tests pass. No clue about integration tests, those seem to require Linux while I'm working on a Windows machine. I've switched to using this version personally, so far it seems to be working fine. The wildcard bug is indeed resolved.